### PR TITLE
Add a variable to allow for customization of the directory from which tests are run

### DIFF
--- a/dap-java.el
+++ b/dap-java.el
@@ -60,6 +60,11 @@ If the port is taken, DAP will try the next port."
   :group 'dap-java
   :type 'number)
 
+(defvar-local dap-java-test-run-directory nil
+  "The directory from which dap-java will run a test.")
+
+(put 'dap-java-test-run-directory 'safe-local-variable #'stringp)
+
 (defun dap-java--select-main-class ()
   "Select main class from the current workspace."
   (let* ((main-classes (lsp-send-execute-command "vscode.java.resolveMainClass"))
@@ -91,7 +96,8 @@ Please check whether the server is configured propertly"))
 
   (-let [(&plist :mainClass main-class :projectName project-name) conf]
     (dap--put-if-absent conf :args "")
-    (dap--put-if-absent conf :cwd (lsp-java--get-root))
+    (dap--put-if-absent conf :cwd (or dap-java-test-run-directory
+                                      (lsp-java--get-root)))
     (dap--put-if-absent conf :stopOnEntry :json-false)
     (dap--put-if-absent conf :host "localhost")
     (dap--put-if-absent conf :request "launch")
@@ -182,7 +188,8 @@ test."
                                            (if run-method? to-run test-class-name)
                                            dap-java-test-additional-args))
           :environment-variables `(("JUNIT_CLASS_PATH" . ,class-path))
-          :cwd (lsp-java--get-root))))
+          :cwd (or dap-java-test-run-directory
+                   (lsp-java--get-root)))))
 
 (defun dap-java-run-test-method ()
   "Run JUnit test.

--- a/dap-java.el
+++ b/dap-java.el
@@ -61,7 +61,7 @@ If the port is taken, DAP will try the next port."
   :type 'number)
 
 (defvar-local dap-java-test-run-directory nil
-  "The directory from which dap-java will run a test.")
+  "When set, the directory from which dap-java will run a test.")
 
 (put 'dap-java-test-run-directory 'safe-local-variable #'stringp)
 


### PR DESCRIPTION
Hello,

So for my use case, I needed the tests to be run from a directory that is arguably the root directory,
but also arguably not. The project root that lsp-java finds is where the git repo starts, and the real project root is where the pom.xml is, one directory deeper. (I have this layout: `project-root-as-determined-by-lsp-java/project-root-as-I-see-it/test/blah/blah/blah/SomethingTest.java`. I cannot change the directory structure. However, by adding this variable, I am able to accommodate my usecase, which is admittedly an edge-case.

Thank you!