### PR TITLE
Don't call lsp--uri-to-path since pathFormat is path

### DIFF
--- a/dap-mode.el
+++ b/dap-mode.el
@@ -614,7 +614,7 @@ thread exection but the server will log message."
       (-let (((&hash "line" line "column" column "name" name) stack-frame)
              (source (gethash "source" stack-frame)))
         (if source
-            (progn (find-file (lsp--uri-to-path (gethash "path" source)))
+            (progn (find-file (gethash "path" source))
                    (setf (dap--debug-session-active-frame debug-session) stack-frame)
 
                    (goto-char (point-min))

--- a/dap-ui.el
+++ b/dap-ui.el
@@ -602,7 +602,7 @@ DEBUG-SESSION the new breakpoints for FILE-NAME."
 DEBUG-SESSION is the debug session triggering the event."
   (when debug-session
     (-if-let* (((&hash "source" "line" "column") (dap--debug-session-active-frame debug-session))
-               (path (-some->> source (gethash "path") lsp--uri-to-path))
+               (path (-some->> source (gethash "path")))
                (buffer (find-buffer-visiting path)))
         (with-current-buffer buffer
           (goto-char (point-min))


### PR DESCRIPTION
Since `dap--initialize-message` is using `pathFormat` with `path` instead of `uri`, parser side should stop call lsp--uri-to-path too. Else we will have a throw.
``` elisp
(list :command "initialize"
        :arguments (list :clientID "vscode"
                         :clientName "Visual Studio Code"
                         :adapterID adapter-id
                         :pathFormat "path"
                         :linesStartAt1 t
                         :columnsStartAt1 t
                         :supportsVariableType t
                         :supportsVariablePaging t
                         :supportsRunInTerminalRequest t
                         :locale "en-us")
        :type "request")
```