### PR TITLE
Add command to download vscode bits

### DIFF
--- a/README.org
+++ b/README.org
@@ -194,12 +194,14 @@
       #+END_SRC
       This will add the python related configuration to  ~dap-debug~.
 ** Ruby
-   - Download and extract [[https://marketplace.visualstudio.com/items?itemName=rebornix.Ruby][VSCode Ruby Extension]] . Make sure that ~dap-ruby-debug-program~ is: ~("node" path-to-main-js)~ where ~node~ is either "node" if nodejs is on the path or path to nodejs and ~path-to-main-js~ is full path ~./out/debugger/main.js~ which is part of the downloaded VScode package.
-   - Follow the instructions on installing ~rdebug-ide~ from [[https://github.com/rubyide/vscode-ruby/wiki/1.-Debugger-Installation][Ruby Debug Installation]]
-   - Put in your emacs configuration.
-     #+BEGIN_SRC elisp
-       (require 'dap-ruby)
-     #+END_SRC
+    - Download and extract [[https://marketplace.visualstudio.com/items?itemName=rebornix.Ruby][VSCode Ruby Extension]]. You can do that either by:
+      - Calling ~dap-ruby-setup~, the extension will be downloaded and all your path will be automatically set up.
+      - Or download the extension manually. Make sure that ~dap-ruby-debug-program~ is: ~("node" path-to-main-js)~ where ~node~ is either "node" if nodejs is on the path or path to nodejs and ~path-to-main-js~ is full path ~./out/debugger/main.js~ which is part of the downloaded VScode package.
+    - Follow the instructions on installing ~rdebug-ide~ from [[https://github.com/rubyide/vscode-ruby/wiki/1.-Debugger-Installation][Ruby Debug Installation]]
+    - Put in your emacs configuration.
+      #+BEGIN_SRC elisp
+        (require 'dap-ruby)
+      #+END_SRC
 ** LLDB
 *** Installation
     LLDB is a debugger that supports, among others, C, C++, Objective-C and Swift.
@@ -222,6 +224,8 @@
    generate runnable debug configuration. For more details on supported settings
    by the Elixir Debug Server refer to it's documentation.
 ** PHP
+   For easier of setting up vscode extension, you only need to call ~dap-php-setup~ after requiring ~dap-php~.
+   
    This is using [[https://github.com/felixfbecker/vscode-php-debug][felixbecker/vscode-php-debug]]
    ([[https://marketplace.visualstudio.com/items?itemName=felixfbecker.php-debug][downloadable from the marketplace]])
    as dap-server between emacs and the xdebug-extension on the http-server side. Make sure it is trans/compiled to
@@ -234,14 +238,17 @@
 ** Native Debug (GDB/LLDB)
    Using https://github.com/WebFreak001/code-debug
 *** Configuration
-    Download and extract [[https://marketplace.visualstudio.com/items?itemName=webfreak.debug][VSCode extension]] (make sure that ~dap-gdb-lldb-path~ is pointing to the extract location).
+    For easier of setting up vscode extension, you only need call ~dap-gdb-lldb-setup~ after requiring ~dap-gdb-lldb~.
+    
+    Or download and extract [[https://marketplace.visualstudio.com/items?itemName=webfreak.debug][VSCode extension]] (make sure that ~dap-gdb-lldb-path~ is pointing to the extract location).
     #+BEGIN_SRC elisp
       (require 'dap-gdb-lldb)
     #+END_SRC
     Then do ~dap-debug~ or ~dap-debug-edit-template~ and selet GBD or LLDB configuration.
 ** Go
 *** Installation
-    - Download and extract [[https://marketplace.visualstudio.com/items?itemName=ms-vscode.Go][VSCode Go Extension]].
+    - For easier of setting up vscode extension, you only need call ~dap-go-setup~ after requiring ~dap-go~.
+      - Or manually download and extract [[https://marketplace.visualstudio.com/items?itemName=ms-vscode.Go][VSCode Go Extension]].
     - Install the delve command by following instructions on [[https://github.com/go-delve/delve/tree/master/Documentation/installation][delve - installation]].
     - Put in your emacs configuration.
       #+BEGIN_SRC elisp
@@ -250,7 +257,8 @@
 ** Javascript
 *** Firefox
 **** Installation
-     - Download and extract [[https://marketplace.visualstudio.com/items?itemName=hbenl.vscode-firefox-debug][VSCode Firefox Debug Extension]].
+     - For easier of setting up vscode extension, you only need call ~dap-firefox-setup~ after requiring ~dap-firefox~.
+       - Or manually download and extract [[https://marketplace.visualstudio.com/items?itemName=hbenl.vscode-firefox-debug][VSCode Firefox Debug Extension]].
      - Make sure that ~dap-firefox-debug-program~ is pointing to the proper file.
      - Put in your configuration file:
        #+BEGIN_SRC elisp
@@ -260,7 +268,8 @@
      ~dap-debug~ or ~dap-debug-edit-template~ and select the firefox template. For additional documentation on the supported template parameters or about different configuration templates refer to [[https://github.com/hbenl/vscode-firefox-debug][Firefox Debug Adapter]].
 *** Chrome
 **** Installation
-     - Download and extract [[https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-chrome][VSCode Chrome Debug Extension]].
+     - For easier of setting up vscode extension, you only need call ~dap-chrome-setup~ after requiring ~dap-chrome~.
+       - Or manually download and extract [[https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-chrome][VSCode Chrome Debug Extension]].
      - Make sure that ~dap-chrome-debug-program~ is pointing to the proper file.
      - Put in your configuration file:
        #+BEGIN_SRC elisp

--- a/dap-chrome.el
+++ b/dap-chrome.el
@@ -42,7 +42,7 @@
   :group 'dap-chrome
   :type '(repeat string))
 
-(dap-utils-vscode-setup-function "dap-chrome" "msjsdiag" "debugger-for-chrome" "4.11.3"
+(dap-utils-vscode-setup-function "dap-chrome" "msjsdiag" "debugger-for-chrome"
                                  dap-chrome-debug-path)
 
 (defun dap-chrome--populate-start-file-args (conf)

--- a/dap-chrome.el
+++ b/dap-chrome.el
@@ -28,11 +28,22 @@
 ;;; Code:
 
 (require 'dap-mode)
+(require 'dap-utils)
 
-(defcustom dap-chrome-debug-program `("node" ,(expand-file-name "/home/kyoncho/.vscode/extensions/msjsdiag.debugger-for-chrome-4.11.3/out/src/chromeDebug.js"))
+(defcustom dap-chrome-debug-path (expand-file-name "vscode/msjsdiag.debugger-for-chrome"
+                                                   dap-utils-extension-path)
+  "The path to chrome vscode extension."
+  :group 'dap-chrome
+  :type 'string)
+
+(defcustom dap-chrome-debug-program `("node"
+                                      ,(f-join dap-chrome-debug-path "extension/out/src/chromeDebug.js"))
   "The path to the chrome debugger."
   :group 'dap-chrome
   :type '(repeat string))
+
+(dap-utils-vscode-setup-function "dap-chrome" "msjsdiag" "debugger-for-chrome" "4.11.3"
+                                 dap-chrome-debug-path)
 
 (defun dap-chrome--populate-start-file-args (conf)
   "Populate CONF with the required arguments."

--- a/dap-firefox.el
+++ b/dap-firefox.el
@@ -42,7 +42,7 @@
   :group 'dap-firefox
   :type '(repeat string))
 
-(dap-utils-vscode-setup-function "dap-firefox" "hbenl" "vscode-firefox-debug" "1.7.10" dap-firefox-debug-path)
+(dap-utils-vscode-setup-function "dap-firefox" "hbenl" "vscode-firefox-debug" dap-firefox-debug-path)
 
 (defun dap-firefox--populate-start-file-args (conf)
   "Populate CONF with the required arguments."

--- a/dap-firefox.el
+++ b/dap-firefox.el
@@ -28,11 +28,21 @@
 ;;; Code:
 
 (require 'dap-mode)
+(require 'dap-utils)
 
-(defcustom dap-firefox-debug-program `("node" ,(expand-file-name "~/.vscode/extensions/hbenl.vscode-firefox-debug-1.7.8/out/firefoxDebugAdapter.js"))
+(defcustom dap-firefox-debug-path (expand-file-name "vscode/hbenl.vscode-firefox-debug" dap-utils-extension-path)
+  "The path to firefox vscode extension."
+  :group 'dap-firefox
+  :type 'string)
+
+(defcustom dap-firefox-debug-program `("node"
+                                       ,(f-join dap-firefox-debug-path
+                                                "extension/out/firefoxDebugAdapter.js"))
   "The path to the firefox debugger."
   :group 'dap-firefox
   :type '(repeat string))
+
+(dap-utils-vscode-setup-function "dap-firefox" "hbenl" "vscode-firefox-debug" "1.7.10" dap-firefox-debug-path)
 
 (defun dap-firefox--populate-start-file-args (conf)
   "Populate CONF with the required arguments."

--- a/dap-gdb-lldb.el
+++ b/dap-gdb-lldb.el
@@ -40,7 +40,7 @@ Link: https://marketplace.visualstudio.com/items?itemName=webfreak.debug ."
   :group 'dap-gdb-lldb
   :type '(repeat string))
 
-(dap-utils-vscode-setup-function "dap-gdb-lldb" "webfreak" "debug" "0.23.1" dap-gdb-lldb-path)
+(dap-utils-vscode-setup-function "dap-gdb-lldb" "webfreak" "debug" dap-gdb-lldb-path)
 
 (defun dap-gdb-lldb--populate-gdb (conf)
   "Populate CONF with the required arguments."

--- a/dap-gdb-lldb.el
+++ b/dap-gdb-lldb.el
@@ -28,16 +28,19 @@
 
 (require 'dap-mode)
 
-(defcustom dap-gdb-lldb-path (expand-file-name "~/.extensions/webfreak.debug")
+(defcustom dap-gdb-lldb-path (expand-file-name "vscode/webfreak.debug" dap-utils-extension-path)
   "The path to the place at which the webfreak.debug extension.
 Link: https://marketplace.visualstudio.com/items?itemName=webfreak.debug ."
   :group 'dap-gdb-lldb
   :type 'string)
 
-(defcustom dap-gdb-lldb-debug-program `("node" ,(expand-file-name (f-join dap-gdb-lldb-path "extension/out/src/gdb.js")))
+(defcustom dap-gdb-lldb-debug-program `("node"
+                                        ,(f-join dap-gdb-lldb-path "extension/out/src/gdb.js"))
   "The path to the LLDB debugger."
   :group 'dap-gdb-lldb
   :type '(repeat string))
+
+(dap-utils-vscode-setup-function "dap-gdb-lldb" "webfreak" "debug" "0.23.1" dap-gdb-lldb-path)
 
 (defun dap-gdb-lldb--populate-gdb (conf)
   "Populate CONF with the required arguments."

--- a/dap-go.el
+++ b/dap-go.el
@@ -47,7 +47,7 @@
   :group 'dap-go
   :type 'string)
 
-(dap-utils-vscode-setup-function "dap-go" "ms-vscode" "go" "0.9.2" dap-go-debug-path)
+(dap-utils-vscode-setup-function "dap-go" "ms-vscode" "go" dap-go-debug-path)
 
 (defun dap-go--populate-default-args (conf)
   "Populate CONF with the default arguments."
@@ -86,47 +86,45 @@
       (plist-put conf :mode "test")
     (plist-put conf :mode "debug")))
 
-(with-eval-after-load 'dap-mode
-  (dap-register-debug-provider "go" 'dap-go--populate-default-args)
-  (dap-register-debug-template "Go Launch File Configuration"
-                               (list :type "go"
-                                     :request "launch"
-                                     :name "Launch File"
-                                     :mode "auto"
-                                     :program nil
-                                     :buildFlags nil
-                                     :args nil
-                                     :env nil
-                                     :envFile nil))
-  (dap-register-debug-template "Go Launch Debug Package Configuration"
-                               (list :type "go"
-                                     :request "launch"
-                                     :name "Launch Debug Package"
-                                     :mode "debug"
-                                     :program nil
-                                     :buildFlags nil
-                                     :args nil
-                                     :env nil
-                                     :envFile nil))
-  (dap-register-debug-template "Go Launch Executable Configuration"
-                               (list :type "go"
-                                     :request "launch"
-                                     :name "Launch Executable"
-                                     :mode "exec"
-                                     :program nil
-                                     :args nil
-                                     :env nil
-                                     :envFile nil))
-  (dap-register-debug-template "Go Attach Executable Configuration"
-                               (list :type "go"
-                                     :request "launch"
-                                     :name "Attach Executable"
-                                     :mode "remote"
-                                     :program nil
-                                     :args nil
-                                     :env nil
-                                     :envFile nil))
-  )
+(dap-register-debug-provider "go" 'dap-go--populate-default-args)
+(dap-register-debug-template "Go Launch File Configuration"
+                             (list :type "go"
+                                   :request "launch"
+                                   :name "Launch File"
+                                   :mode "auto"
+                                   :program nil
+                                   :buildFlags nil
+                                   :args nil
+                                   :env nil
+                                   :envFile nil))
+(dap-register-debug-template "Go Launch Debug Package Configuration"
+                             (list :type "go"
+                                   :request "launch"
+                                   :name "Launch Debug Package"
+                                   :mode "debug"
+                                   :program nil
+                                   :buildFlags nil
+                                   :args nil
+                                   :env nil
+                                   :envFile nil))
+(dap-register-debug-template "Go Launch Executable Configuration"
+                             (list :type "go"
+                                   :request "launch"
+                                   :name "Launch Executable"
+                                   :mode "exec"
+                                   :program nil
+                                   :args nil
+                                   :env nil
+                                   :envFile nil))
+(dap-register-debug-template "Go Attach Executable Configuration"
+                             (list :type "go"
+                                   :request "launch"
+                                   :name "Attach Executable"
+                                   :mode "remote"
+                                   :program nil
+                                   :args nil
+                                   :env nil
+                                   :envFile nil))
 
 (provide 'dap-go)
 ;;; dap-go.el ends here

--- a/dap-go.el
+++ b/dap-go.el
@@ -28,10 +28,15 @@
 ;;; Code:
 
 (require 'dap-mode)
+(require 'dap-utils)
+
+(defcustom dap-go-debug-path (expand-file-name "vscode/ms-vscode.go" dap-utils-extension-path)
+  "The path to go vscode extension."
+  :group 'dap-go
+  :type 'string)
 
 (defcustom dap-go-debug-program `("node"
-                                  ,(concat (file-name-directory (or load-file-name buffer-file-name))
-                                           "/bin/go/out/src/debugAdapter/goDebug.js"))
+                                  ,(f-join dap-go-debug-path "extension/out/src/debugAdapter/goDebug.js"))
   "The path to the go debugger."
   :group 'dap-go
   :type '(repeat string))
@@ -41,6 +46,8 @@
   "The path to the delve command."
   :group 'dap-go
   :type 'string)
+
+(dap-utils-vscode-setup-function "dap-go" "ms-vscode" "go" "0.9.2" dap-go-debug-path)
 
 (defun dap-go--populate-default-args (conf)
   "Populate CONF with the default arguments."
@@ -79,48 +86,47 @@
       (plist-put conf :mode "test")
     (plist-put conf :mode "debug")))
 
-(eval-after-load "dap-mode"
-  '(progn
-     (dap-register-debug-provider "go" 'dap-go--populate-default-args)
-     (dap-register-debug-template "Go Launch File Configuration"
-                                  (list :type "go"
-                                        :request "launch"
-                                        :name "Launch File"
-                                        :mode "auto"
-                                        :program nil
-                                        :buildFlags nil
-                                        :args nil
-                                        :env nil
-                                        :envFile nil))
-     (dap-register-debug-template "Go Launch Debug Package Configuration"
-                                  (list :type "go"
-                                        :request "launch"
-                                        :name "Launch Debug Package"
-                                        :mode "debug"
-                                        :program nil
-                                        :buildFlags nil
-                                        :args nil
-                                        :env nil
-                                        :envFile nil))
-     (dap-register-debug-template "Go Launch Executable Configuration"
-                                  (list :type "go"
-                                        :request "launch"
-                                        :name "Launch Executable"
-                                        :mode "exec"
-                                        :program nil
-                                        :args nil
-                                        :env nil
-                                        :envFile nil))
-     (dap-register-debug-template "Go Attach Executable Configuration"
-                                  (list :type "go"
-                                        :request "launch"
-                                        :name "Attach Executable"
-                                        :mode "remote"
-                                        :program nil
-                                        :args nil
-                                        :env nil
-                                        :envFile nil))
-     ))
+(with-eval-after-load 'dap-mode
+  (dap-register-debug-provider "go" 'dap-go--populate-default-args)
+  (dap-register-debug-template "Go Launch File Configuration"
+                               (list :type "go"
+                                     :request "launch"
+                                     :name "Launch File"
+                                     :mode "auto"
+                                     :program nil
+                                     :buildFlags nil
+                                     :args nil
+                                     :env nil
+                                     :envFile nil))
+  (dap-register-debug-template "Go Launch Debug Package Configuration"
+                               (list :type "go"
+                                     :request "launch"
+                                     :name "Launch Debug Package"
+                                     :mode "debug"
+                                     :program nil
+                                     :buildFlags nil
+                                     :args nil
+                                     :env nil
+                                     :envFile nil))
+  (dap-register-debug-template "Go Launch Executable Configuration"
+                               (list :type "go"
+                                     :request "launch"
+                                     :name "Launch Executable"
+                                     :mode "exec"
+                                     :program nil
+                                     :args nil
+                                     :env nil
+                                     :envFile nil))
+  (dap-register-debug-template "Go Attach Executable Configuration"
+                               (list :type "go"
+                                     :request "launch"
+                                     :name "Attach Executable"
+                                     :mode "remote"
+                                     :program nil
+                                     :args nil
+                                     :env nil
+                                     :envFile nil))
+  )
 
 (provide 'dap-go)
 ;;; dap-go.el ends here

--- a/dap-php.el
+++ b/dap-php.el
@@ -42,7 +42,7 @@
   :group 'dap-php
   :type '(repeat string))
 
-(dap-utils-vscode-setup-function "dap-php" "felixfbecker" "php-debug" "1.13.0" dap-php-debug-path)
+(dap-utils-vscode-setup-function "dap-php" "felixfbecker" "php-debug" dap-php-debug-path)
 
 (defun dap-php--populate-start-file-args (conf)
   "Populate CONF with the required arguments."

--- a/dap-php.el
+++ b/dap-php.el
@@ -29,11 +29,20 @@
 ;;; Code:
 
 (require 'dap-mode)
+(require 'dap-utils)
 
-(defcustom dap-php-debug-program `("node" ,(expand-file-name "~/.extensions/php/out/phpDebug.js"))
+(defcustom dap-php-debug-path (expand-file-name "vscode/felixfbecker.php-debug" dap-utils-extension-path)
+  "The path to php-debug vscode extension."
+  :group 'dap-php
+  :type 'string)
+
+(defcustom dap-php-debug-program `("node"
+                                   ,(f-join dap-php-debug-path "extension/out/phpDebug.js"))
   "The path to the php debugger."
   :group 'dap-php
   :type '(repeat string))
+
+(dap-utils-vscode-setup-function "dap-php" "felixfbecker" "php-debug" "1.13.0" dap-php-debug-path)
 
 (defun dap-php--populate-start-file-args (conf)
   "Populate CONF with the required arguments."

--- a/dap-ruby.el
+++ b/dap-ruby.el
@@ -28,11 +28,20 @@
 ;;; Code:
 
 (require 'dap-mode)
+(require 'dap-utils)
 
-(defcustom dap-ruby-debug-program `("node" ,(expand-file-name "~/.extensions/ruby/out/debugger/main.js"))
+(defcustom dap-ruby-debug-path (expand-file-name "vscode/rebornix.Ruby" dap-utils-extension-path)
+  "The path to ruby vscode extension."
+  :group 'dap-ruby
+  :type 'string)
+
+(defcustom dap-ruby-debug-program `("node"
+                                    ,(f-join dap-ruby-debug-path "extension/out/debugger/main.js"))
   "The path to the ruby debugger."
   :group 'dap-ruby
   :type '(repeat string))
+
+(dap-utils-vscode-setup-function "dap-ruby" "rebornix" "Ruby" "0.22.3" dap-ruby-debug-path)
 
 (defun dap-ruby--populate-start-file-args (conf)
   "Populate CONF with the required arguments."

--- a/dap-ruby.el
+++ b/dap-ruby.el
@@ -41,7 +41,7 @@
   :group 'dap-ruby
   :type '(repeat string))
 
-(dap-utils-vscode-setup-function "dap-ruby" "rebornix" "Ruby" "0.22.3" dap-ruby-debug-path)
+(dap-utils-vscode-setup-function "dap-ruby" "rebornix" "Ruby" dap-ruby-debug-path)
 
 (defun dap-ruby--populate-start-file-args (conf)
   "Populate CONF with the required arguments."

--- a/dap-utils.el
+++ b/dap-utils.el
@@ -61,26 +61,27 @@
   :group 'dap-utils
   :type 'directory)
 
-(defun dap-utils-get-vscode-extension (publisher name version &optional path)
+(defun dap-utils-get-vscode-extension (publisher name &optional version path)
   "Get vscode extension named NAME with VERSION."
-  (let ((url (format dap-utils-vscode-ext-url publisher name version))
-        (dest (or path
-                  (f-join dap-utils-extension-path "vscode" (concat publisher "." name)))))
+  (let* ((version (or version "latest"))
+         (url (format dap-utils-vscode-ext-url publisher name version))
+         (dest (or path
+                   (f-join dap-utils-extension-path "vscode" (concat publisher "." name)))))
     (dap-utils--get-extension url dest)))
 
-(defmacro dap-utils-vscode-setup-function (dapfile publisher name version &optional path)
+(defmacro dap-utils-vscode-setup-function (dapfile publisher name &optional path)
   "Helper to create setup function for vscode debug extension."
   (let* ((extension-name (concat publisher "." name))
          (dest (or path
-                  (f-join dap-utils-extension-path "vscode" extension-name)))
-        (help-string (format "Downloading %s to path specified.
+                   (f-join dap-utils-extension-path "vscode" extension-name)))
+         (help-string (format "Downloading %s to path specified.
 With prefix, FORCED to redownload the extension." extension-name)))
     `(progn
        (defun ,(intern (format "%s-setup" dapfile)) (&optional forced)
          ,help-string
          (interactive "P")
          (unless (and (not forced) (file-exists-p ,dest))
-           (dap-utils-get-vscode-extension ,publisher ,name ,version)
+           (dap-utils-get-vscode-extension ,publisher ,name nil ,dest)
            (message "%s: Downloading done!" ,dapfile)))
        (unless (file-exists-p ,dest)
          (message "%s: %s debug extension are not set. You can download it with M-x %s-setup"

--- a/dap-utils.el
+++ b/dap-utils.el
@@ -29,7 +29,7 @@
 
 (require 'dap-mode)
 
-(defconst dap-utils--ext-unzip-script "unzip -qq %s -d %s"
+(defconst dap-utils--ext-unzip-script "mkdir -p %2$s && unzip -qq %1$s -d %2$s"
   "Unzip script to unzip vscode extension package file.")
 
 (defconst dap-utils--ext-pwsh-script "powershell -noprofile -noninteractive \

--- a/dap-utils.el
+++ b/dap-utils.el
@@ -1,0 +1,91 @@
+;;; dap-utils.el --- DAP UTILS -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2019  Kien Nguyen
+
+;; Author: Kien Nguyen <kien.n.quang@gmail.com>
+;; Keywords: languages, utils
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;; URL: https://github.com/yyoncho/dap-mode
+;; Package-Requires: ((emacs "25.1"))
+;; Version: 0.2
+
+;;; Commentary:
+;; Dap-mode utils
+
+;;; Code:
+
+(require 'dap-mode)
+
+(defconst dap-utils--ext-unzip-script "unzip -qq %s -d %s"
+  "Unzip script to unzip vscode extension package file.")
+
+(defconst dap-utils--ext-pwsh-script "powershell -noprofile -noninteractive \
+-nologo -ex bypass Expand-Archive -path '%s' -dest '%s'"
+  "Powershell script to unzip vscode extension package file.")
+
+(defcustom dap-utils-unzip-script (cond ((executable-find "unzip") dap-utils--ext-unzip-script)
+                                        ((executable-find "powershell") dap-utils--ext-pwsh-script)
+                                        (t nil))
+  "The script to unzip vscode extension package file."
+  :group 'dap-utils
+  :type 'string)
+
+(defun dap-utils--get-extension (url dest)
+  "Get extension from URL and extract to DEST."
+  (let ((temp-file (make-temp-file "ext" nil ".zip")))
+    (url-copy-file url temp-file 'overwrite)
+    (if (file-exists-p dest) (delete-directory dest 'recursive))
+    (shell-command (format dap-utils-unzip-script temp-file dest))))
+
+(defcustom dap-utils-vscode-ext-url
+  "https://marketplace.visualstudio.com/_apis/public/gallery/publishers/%s/vsextensions/%s/%s/vspackage"
+  "Vscode extension template url."
+  :group 'dap-utils
+  :type 'string)
+
+(defcustom dap-utils-extension-path (expand-file-name ".extension" user-emacs-directory)
+  "Directory to store vscode extension."
+  :group 'dap-utils
+  :type 'directory)
+
+(defun dap-utils-get-vscode-extension (publisher name version &optional path)
+  "Get vscode extension named NAME with VERSION."
+  (let ((url (format dap-utils-vscode-ext-url publisher name version))
+        (dest (or path
+                  (f-join dap-utils-extension-path "vscode" (concat publisher "." name)))))
+    (dap-utils--get-extension url dest)))
+
+(defmacro dap-utils-vscode-setup-function (dapfile publisher name version &optional path)
+  "Helper to create setup function for vscode debug extension."
+  (let* ((extension-name (concat publisher "." name))
+         (dest (or path
+                  (f-join dap-utils-extension-path "vscode" extension-name)))
+        (help-string (format "Downloading %s to path specified.
+With prefix, FORCED to redownload the extension." extension-name)))
+    `(progn
+       (defun ,(intern (format "%s-setup" dapfile)) (&optional forced)
+         ,help-string
+         (interactive "P")
+         (unless (and (not forced) (file-exists-p ,dest))
+           (dap-utils-get-vscode-extension ,publisher ,name ,version)
+           (message "%s: Downloading done!" ,dapfile)))
+       (unless (file-exists-p ,dest)
+         (message "%s: %s debug extension are not set. You can download it with M-x %s-setup"
+                  ,dapfile ,extension-name ,dapfile)))))
+
+(provide 'dap-utils)
+;;; dap-utils.el ends here
+


### PR DESCRIPTION
Instead of having manually download the `VsCode` extensions, we should be able to automatically/effortlessly download those extensions right from `Emacs`.
This changes provided:
- `dap-utils-get-vscode-extension` to download `VsCode` extension to specified path.
- Update `dap-chrome`, `dap-firefox`, `dap-gdb-llb`, `dap-go`, `dap-php` and `dap-ruby` to leverage new utilities function.
- Create new `dap-go-setup` series of command to download `VsCode` extension.