### PR TITLE
Only navigate to source files if we have a path

### DIFF
--- a/dap-mode.el
+++ b/dap-mode.el
@@ -611,15 +611,18 @@ thread exection but the server will log message."
   "Make STACK-FRAME the active STACK-FRAME of DEBUG-SESSION."
   (let ((lsp--cur-workspace (dap--debug-session-workspace debug-session)))
     (when stack-frame
-      (-let (((&hash "line" line "column" column "name" name) stack-frame)
-             (source (gethash "source" stack-frame)))
-        (if source
-            (progn (find-file (gethash "path" source))
-                   (setf (dap--debug-session-active-frame debug-session) stack-frame)
-
+      (-let* (((&hash "line" line "column" column "name" name) stack-frame)
+              (source (gethash "source" stack-frame))
+              (path (gethash "path" source)))
+        (setf (dap--debug-session-active-frame debug-session) stack-frame)
+        ;; If we have a source file with path attached, open it and
+        ;; position the point in the line/column referenced in the
+        ;; stack trace.
+        (if (and source path)
+            (progn (find-file path)
                    (goto-char (point-min))
-                   (forward-line (1- (gethash "line" stack-frame)))
-                   (forward-char (gethash "column" stack-frame)))
+                   (forward-line (1- line))
+                   (forward-char column))
           (message "No source code for %s. Cursor at %s:%s." name line column))))
     (run-hook-with-args 'dap-stack-frame-changed-hook debug-session)))
 

--- a/dap-mode.el
+++ b/dap-mode.el
@@ -613,12 +613,12 @@ thread exection but the server will log message."
     (when stack-frame
       (-let* (((&hash "line" line "column" column "name" name) stack-frame)
               (source (gethash "source" stack-frame))
-              (path (gethash "path" source)))
+              (path (and source (gethash "path" source))))
         (setf (dap--debug-session-active-frame debug-session) stack-frame)
         ;; If we have a source file with path attached, open it and
         ;; position the point in the line/column referenced in the
         ;; stack trace.
-        (if (and source path)
+        (if path
             (progn (find-file path)
                    (goto-char (point-min))
                    (forward-line (1- line))


### PR DESCRIPTION
According to the spec, "path" is an optional property of a Source, so
in some cases, stack frames may have a "source" but no "path"
inside (for example, if the stack frame is OS library code). We now
only try to open a source file if there is a path attached.

Previously, in those cases we tried to execute `(find-file nil)`, which 
aborted the program.