### PR TITLE
Protect dap-ui--make-overlay-at if the point is nil

### DIFF
--- a/dap-ui.el
+++ b/dap-ui.el
@@ -501,15 +501,14 @@ BUF is the active buffer."
 
 (defun dap-ui--make-overlay-at (file point msg visuals)
   "Create an overlay highlighting the given POINT in FILE.
-B is the beginning of the overlay.
-E is the ending of the overlay.
 VISUALS and MSG will be used for the overlay."
   (-when-let (buf (find-buffer-visiting file))
     (with-current-buffer buf
-      ;; If line provided, use line to define region
-      (save-excursion
-        (goto-char point)
-        (dap-ui--make-overlay (point-at-bol) (point-at-eol) msg visuals nil buf)))))
+      ;; If point is provided, use it to define region
+      (when (integer-or-marker-p point)
+        (save-excursion
+          (goto-char point)
+          (dap-ui--make-overlay (point-at-bol) (point-at-eol) msg visuals nil buf))))))
 
 (defvar-local dap-ui--breakpoint-overlays '())
 


### PR DESCRIPTION
Remove B and E from the documentation, as the parameters were
refactored recently.

If the point is not a mark or an integer, bail without creating an
overlay.