### PR TITLE
Remove unnecessary config element

### DIFF
--- a/dap-php.el
+++ b/dap-php.el
@@ -58,7 +58,6 @@
                                    :cwd nil
                                    :request "launch"
                                    :name "Php Debug"
-                                   :args '("--server=4711")
                                    :sourceMaps t
                                    ))
 


### PR DESCRIPTION
The server port isn't set this way.  The line is a remnant of the trial and error phase of setting up php debugging.