### PR TITLE
Add 'stop on entry' debugging template for php

### DIFF
--- a/dap-php.el
+++ b/dap-php.el
@@ -58,6 +58,15 @@
                                    :cwd nil
                                    :request "launch"
                                    :name "Php Debug"
+                                   :args '("--server=4711")
+                                   :sourceMaps t
+                                   ))
+(dap-register-debug-template "Php Stop On Entry"
+                             (list :type "php"
+                                   :cwd nil
+                                   :request "launch"
+                                   :name "Php SOE Debug"
+                                   :stopOnEntry t
                                    :sourceMaps t
                                    ))
 


### PR DESCRIPTION
Sometimes (mostly when debugging command-line tools), I don't want to/can set a breakpoint, but just want to enter the debugger from the start.  This resembles gebens default behaviour, IIRC.