### PR TITLE
filter output buffer, label by category, and add output buffer scrolling

### DIFF
--- a/dap-mode.el
+++ b/dap-mode.el
@@ -719,9 +719,7 @@ thread exection but the server will log message."
     (pcase event-type
       ("output" (let* ((event-body (gethash "body" event))
                        (formatted-output (dap--output-buffer-format event-body)))
-                  (if dap-output-buffer-filter
-                      (when (member (gethash "category" event-body) dap-output-buffer-filter)
-                        (dap--print-to-output-buffer debug-session formatted-output))
+                  (when (or (not dap-output-buffer-filter) (member (gethash "category" event-body) dap-output-buffer-filter))
                     (dap--print-to-output-buffer debug-session formatted-output))))
       ("breakpoint" (-when-let* (((breakpoint &as &hash "id") (-some->> event
                                                                         (gethash "body")

--- a/dap-mode.el
+++ b/dap-mode.el
@@ -711,8 +711,7 @@ thread exection but the server will log message."
   (with-current-buffer (dap--debug-session-output-buffer debug-session)
     (let ((win (get-buffer-window (current-buffer))))
       (goto-char (point-max))
-      (insert str)
-      (set-window-point win (point-max)))))
+      (insert str))))
 
 (defun dap--on-event (debug-session event)
   "Dispatch EVENT for DEBUG-SESSION."
@@ -791,6 +790,12 @@ thread exection but the server will log message."
                                 (message "Unable to find handler for %s." (pp parsed-msg)))))))
             (dap--parser-read parser msg)))))
 
+(defun dap--create-output-buffer (session-name)
+  "Creates an output buffer with with name SESSION-NAME."
+  (with-current-buffer (get-buffer-create (concat "*" session-name " out*"))
+    (set (make-local-variable 'window-point-insertion-type) t)
+    (current-buffer)))
+
 (defun dap--make-request (command &optional args)
   "Make request for COMMAND with arguments ARGS."
   (if args
@@ -850,7 +855,7 @@ ADAPTER-ID the id of the adapter."
                           :launch-args launch-args
                           :proc proc
                           :name session-name
-                          :output-buffer (get-buffer-create (concat "*" session-name " out*"))
+                          :output-buffer (dap--create-output-buffer session-name)
                           :workspace lsp--cur-workspace)))
     (set-process-sentinel proc
                           (lambda (_process exit-str)

--- a/dap-mode.el
+++ b/dap-mode.el
@@ -43,7 +43,7 @@
   :group 'dap-mode
   :type 'boolean)
 
-(defcustom dap-output-buffer-filter '("stdout")
+(defcustom dap-output-buffer-filter '("stdout" "stderr")
   "If non-nil, a list of output types to display in the debug output buffer."
   :group 'dap-mode
   :type 'list)

--- a/dap-mode.el
+++ b/dap-mode.el
@@ -706,11 +706,19 @@ thread exection but the server will log message."
       (dap--output-buffer-format-with-category (gethash "category" output-body) (gethash "output" output-body))
     (gethash "output" output-body)))
 
+(defun dap--insert-at-point-max (str)
+  "Inserts STR at point-max of the buffer."
+  (goto-char (point-max))
+  (insert str))
+
 (defun dap--print-to-output-buffer (debug-session str)
   "Insert content from STR into the output buffer associated with DEBUG-SESSION."
   (with-current-buffer (dap--debug-session-output-buffer debug-session)
-    (goto-char (point-max))
-    (insert str)))
+    (if (and (eq (current-buffer) (window-buffer (selected-window)))
+             (not (= (point) (point-max))))
+        (save-excursion
+          (dap--insert-at-point-max str))
+      (dap--insert-at-point-max str))))
 
 (defun dap--on-event (debug-session event)
   "Dispatch EVENT for DEBUG-SESSION."

--- a/dap-mode.el
+++ b/dap-mode.el
@@ -709,9 +709,8 @@ thread exection but the server will log message."
 (defun dap--print-to-output-buffer (debug-session str)
   "Insert content from STR into the output buffer associated with DEBUG-SESSION."
   (with-current-buffer (dap--debug-session-output-buffer debug-session)
-    (let ((win (get-buffer-window (current-buffer))))
-      (goto-char (point-max))
-      (insert str))))
+    (goto-char (point-max))
+    (insert str)))
 
 (defun dap--on-event (debug-session event)
   "Dispatch EVENT for DEBUG-SESSION."


### PR DESCRIPTION
I am pretty new to this project, so feedback is greatly appreciated! Thanks 

closes #120 

## Reasoning behind this PR
- When debugging an application (nodejs in my case), it is difficult to distinguish stdout from other DAP output in the output buffer. See #120 
- The output buffer did not scroll when new output was printed to the buffer.

# What I added:
## Filtering output based on category of the DAP output
You can now use the custom `dap-output-buffer-filter` to filter the output based on the categories you want to see. I have set the default as "stdout", because I thought that the telemetry output such as "FullSessionStatistics/SourceMaps/Overrides" was not very helpful when debugging a program.

Result:
Consider this simple program
```nodejs
for (let i = 0; i < 10; i++) {
  console.log(i);
}
```

With `dap-output-buffer-filter` set to `'("stdout")`, the output buffer now produces this output:
```
0
1
2
3
4
5
6
7
8
9
```

## Labelling categories in output
You can use the custom `dap-label-output-buffer-category` to show the category that the output belongs to in the output buffer.
Now, the output buffer formats like this when the custom is non-nil:
```telemetry: ClientRequest/initialize
telemetry: debugStarted
console: /usr/local/bin/node --inspect-brk=5755 main.js 
stderr: Debugger listening on ws://127.0.0.1:5755/619ee71b-ada8-419c-932c-e64ba663392c
For help, see: https://nodejs.org/en/docs/inspector
telemetry: targetDebugProtocolVersion
telemetry: targetCount
stderr: Debugger attached.
telemetry: ClientRequest/launch
telemetry: nodeVersion
telemetry: setBreakpointsRequest
telemetry: ClientRequest/setBreakpoints
telemetry: report-start-up-timings
telemetry: ClientRequest/configurationDone
telemetry: ClientRequest/stackTrace
telemetry: FullSessionStatistics/SourceMaps/Overrides
telemetry: target/notification/onScriptParsed
telemetry: target/notification/onPaused
telemetry: ClientRequest/disconnect
telemetry: debugStopped
```

## Proper Scrolling of Output buffer
The output buffer was not properly scrolling because although the buffer's point was being set to `(point-max)`, the window's point was not. This was fixed by adding `(set-window-point win (point-max))` after inserting text to the output buffer. 