### PR TITLE
Fix breakpoints broken in multibyte character environment

### DIFF
--- a/dap-mode.el
+++ b/dap-mode.el
@@ -882,7 +882,7 @@ ADAPTER-ID the id of the adapter."
   "Make `setBreakpoints' request for FILE-NAME.
 FILE-BREAKPOINTS is a list of the breakpoints to set for FILE-NAME."
   (with-temp-buffer
-    (insert-file-contents-literally file-name)
+    (insert-file-contents file-name)
     (dap--make-request
      "setBreakpoints"
      (list :source (list :name (f-filename file-name)
@@ -1058,7 +1058,7 @@ should be started after the :port argument is taken.
 (defun dap--read-from-file (file)
   "Read FILE content."
   (with-temp-buffer
-    (insert-file-contents-literally file)
+    (insert-file-contents file)
     (cl-first (read-from-string
                (buffer-substring-no-properties (point-min) (point-max))))))
 

--- a/dap-ui.el
+++ b/dap-ui.el
@@ -856,7 +856,7 @@ REQUEST-ID is the active request id. If it doesn't maches the
                                                    dap--debug-session-breakpoints
                                                    (gethash file-name))))
                 (with-temp-buffer
-                  (insert-file-contents-literally file-name)
+                  (insert-file-contents file-name)
                   (mapc
                    (-lambda (((&plist :point :condition :hit-condition :log-message) . remote-bp))
                      (push `((id ,(setq id (1+ id)))


### PR DESCRIPTION
In multibyte character environment, the breakpoints can be unusable for two reasons:

1. If there are multibyte characters in source code, the breakpoints will be shifted upward (see screenshot below)
![Screenshot from 2019-09-17 00-50-21](https://user-images.githubusercontent.com/227146/65014109-89936b00-d958-11e9-9982-10c3b0d212ff.png)
2. If file path includes multibyte characters (e.g. `~/あいう/src/main.rs`), the breakpoints cannot be read from .dap-breakpoints

I confirmed these problem are caused by insert-file-contents-literally() and can be resolved by using insert-file-contents() instead.
