### PR TITLE
Correct dap--get-path-for-frame to work in Windows

### DIFF
--- a/dap-mode.el
+++ b/dap-mode.el
@@ -651,9 +651,12 @@ thread exection but the server will log message."
 
 (defun dap--get-path-for-frame (stack-frame)
   "Get file path for a STACK-FRAME."
-  (-when-let* ((source (gethash "source" stack-frame))
-               (path (gethash "path" source)))
-    (if (-> path url-unhex-string url-generic-parse-url url-type)
+  (-when-let ((path (-some->> stack-frame
+                              (gethash "source")
+                              (gethash "path"))))
+    (if (-> path url-unhex-string url-generic-parse-url url-type
+            ;; In windows, the fullpath is containing a drive name
+            length (> 1))
         (lsp--uri-to-path path)
       path)))
 


### PR DESCRIPTION
In `Windows`, absolute path is treated as url with `url-type` is name of driver.
For example `C:\example` will be parsed as url with `url-type` of `C`.
This cases the problem for `lsp--uri-to-path`.
We need to filter out `url-type` of one character long for it to work properly.