### PR TITLE
Render ansi colors in output buffers

### DIFF
--- a/dap-mode.el
+++ b/dap-mode.el
@@ -32,6 +32,7 @@
 (require 'dash)
 (require 'dap-overlays)
 (require 'cl-lib)
+(require 'ansi-color)
 
 (defcustom dap-breakpoints-file (expand-file-name (locate-user-emacs-file ".dap-breakpoints"))
   "Where to persist breakpoints"
@@ -739,16 +740,19 @@ thread exection but the server will log message."
 (defun dap--insert-at-point-max (str)
   "Inserts STR at point-max of the buffer."
   (goto-char (point-max))
-  (insert str))
+  (insert (ansi-color-apply str)))
 
 (defun dap--print-to-output-buffer (debug-session str)
   "Insert content from STR into the output buffer associated with DEBUG-SESSION."
   (with-current-buffer (get-buffer-create (dap--debug-session-output-buffer debug-session))
+    (font-lock-mode t)
+    (setq-local buffer-read-only nil)
     (if (and (eq (current-buffer) (window-buffer (selected-window)))
              (not (= (point) (point-max))))
         (save-excursion
           (dap--insert-at-point-max str))
-      (dap--insert-at-point-max str))))
+      (dap--insert-at-point-max str))
+    (setq-local buffer-read-only t)))
 
 (defun dap--on-event (debug-session event)
   "Dispatch EVENT for DEBUG-SESSION."


### PR DESCRIPTION
Before:
![screenshot-2020-01-31-16:55:49](https://user-images.githubusercontent.com/2943605/73545641-a2964780-4433-11ea-8391-b5c96db70a50.png)
After:
![screenshot-2020-01-31-16:55:57](https://user-images.githubusercontent.com/2943605/73545646-a629ce80-4433-11ea-87a9-d4c764febfdf.png)

I also made these buffers read-only.
