### PR TITLE
Fix the derivation of defcustom dap-java-test-runner.

### DIFF
--- a/dap-java.el
+++ b/dap-java.el
@@ -46,7 +46,7 @@ If the port is taken, DAP will try the next port."
   :type 'number)
 
 (defcustom dap-java-test-runner
-  (expand-file-name (locate-user-emacs-file "eclipse.jdt.ls/test-runner/junit-platform-console-standalone.jar"))
+  (expand-file-name (concat lsp-java-server-install-dir "test-runner/junit-platform-console-standalone.jar"))
   "DAP Java test runner."
   :group 'dap-java-java
   :type 'file)


### PR DESCRIPTION
After changes to 'defcustom lsp-server-install-dir' in 'lsp-mode'
and 'defcustom lsp-java-server-install-dir' in 'lsp-java', 'dap-java'
cannot successfully derive the test runner jar file.

This change fixes that by concatenating the variable
'lsp-java-server-install-dir' with the relative path where the junit
test runner jar file is expected to be found.