### PR TITLE
Removed java mentioning from breakpoint description

### DIFF
--- a/README.org
+++ b/README.org
@@ -113,7 +113,7 @@
    |--------------------------------+-----------------------------------------------------------------|
    | ~dap-breakpoint-toggle~        | Toggle breakpoint at line                                       |
    | ~dap-breakpoint-delete~        | Delete breakpoint at line                                       |
-   | ~dap-breakpoint-add~           | Add java breakpoint at line                                     |
+   | ~dap-breakpoint-add~           | Add breakpoint at line                                          |
    | ~dap-breakpoint-condition~     | Set/unset breakpoint condition                                  |
    | ~dap-breakpoint-hit-condition~ | Set/unset breakpoint hit condition                              |
    | ~dap-breakpoint-log-message~   | Set/unset breakpoint log message                                |


### PR DESCRIPTION
Description for `dap-breakpoint-add` says `Add java breakpoint at line`, which seems to be a mistake because it is not tied to Java language.