### PR TITLE
Fix test if posframe is installed

### DIFF
--- a/dap-ui.el
+++ b/dap-ui.el
@@ -521,8 +521,7 @@ DEBUG-SESSION is the debug session triggering the event."
   :init-value nil
   :global t
   :require 'dap-ui
-  (unless (and (fboundp 'posframe-show)
-               (fboundp 'posframe-hide))
+  (unless (require 'posframe nil t)
     (error "Displaying DAP controls requires that the posframe Emacs package is installed"))
   (cond
    (dap-ui-controls-mode


### PR DESCRIPTION
When posframe is installed but not required yet
`(fboundp 'posframe-show)` returns `t` because it's autoloaded
but posframe-hide is not autoloaded (because it doesn't make sense)
and therefore `(fboundp 'posframe-show)` returns `nil`
which then wrongly complains that I need `posframe` installed.