### PR TITLE
update the new path to main.js

### DIFF
--- a/README.org
+++ b/README.org
@@ -253,7 +253,7 @@ case, define a template:
 ** Ruby
     - Download and extract [[https://marketplace.visualstudio.com/items?itemName=rebornix.Ruby][VSCode Ruby Extension]]. You can do that either by:
       - Calling ~dap-ruby-setup~, the extension will be downloaded and all your path will be automatically set up.
-      - Or download the extension manually. Make sure that ~dap-ruby-debug-program~ is: ~("node" path-to-main-js)~ where ~node~ is either "node" if nodejs is on the path or path to nodejs and ~path-to-main-js~ is full path ~./out/debugger/main.js~ which is part of the downloaded VScode package.
+      - Or download the extension manually. Make sure that ~dap-ruby-debug-program~ is: ~("node" path-to-main-js)~ where ~node~ is either "node" if nodejs is on the path or path to nodejs and ~path-to-main-js~ is full path ~./dist/debugger/main.js~ which is part of the downloaded VScode package.
     - Follow the instructions on installing ~rdebug-ide~ from [[https://github.com/rubyide/vscode-ruby/wiki/1.-Debugger-Installation][Ruby Debug Installation]]
     - Put in your emacs configuration.
       #+BEGIN_SRC elisp

--- a/dap-ruby.el
+++ b/dap-ruby.el
@@ -36,7 +36,7 @@
   :type 'string)
 
 (defcustom dap-ruby-debug-program `("node"
-                                    ,(f-join dap-ruby-debug-path "extension/out/debugger/main.js"))
+                                    ,(f-join dap-ruby-debug-path "extension/dist/debugger/main.js"))
   "The path to the ruby debugger."
   :group 'dap-ruby
   :type '(repeat string))


### PR DESCRIPTION
I got this error and found out that the path to main.js has been changed.

```
Error: Cannot find module '/Users/snowflake/.emacs.d/.local/etc/dap-extension/vscode/rebornix.Ruby/extension/out/debugger/main.js'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:982:15)
    at Function.Module._load (internal/modules/cjs/loader.js:864:27)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:74:12)
    at internal/main/run_main_module.js:18:47 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}
```