### PR TITLE
Fix absolute path for icons when using symlink files

### DIFF
--- a/dap-ui.el
+++ b/dap-ui.el
@@ -460,7 +460,7 @@ DEBUG-SESSION is the debug session triggering the event."
 
 
 ;; dap-ui posframe stuff
-(defvar dap-ui--control-images-root-dir (f-join (f-dirname (or load-file-name buffer-file-name)) "icons/vscode"))
+(defvar dap-ui--control-images-root-dir (f-join (f-dirname (file-truename (or load-file-name buffer-file-name))) "icons/vscode"))
 (defvar dap-ui--control-buffer " *dap-ui*")
 
 (defun dap-ui--create-command (image command hover-text)


### PR DESCRIPTION
The problem is that when `buffer-file-name` from [here](https://github.com/emacs-lsp/dap-mode/blob/master/dap-ui.el#L463) returns a symlink, it will build a invalid path for the icons.