### PR TITLE
Add auto configuration mode

### DIFF
--- a/dap-mode.el
+++ b/dap-mode.el
@@ -150,13 +150,13 @@ The hook will be called with the session file and the new set of breakpoint loca
               (const :tag "Enable `dap-ui-controls-mode` with controls to manage the debug session when debugging" controls)
               (const :tag "Enable `dap-tooltip-mode` that enables mouse hover support when debugging" tooltip)))
 
-(defconst dap-feature->start-stop
+(defconst dap-features->windows
   '((sessions . (dap-ui-sessions . dap-ui--sessions-buffer))
     (locals . (dap-ui-locals . dap-ui--locals-buffer))
     (breakpoints . (dap-ui-breakpoints . dap-ui--breakpoints-buffer))
     (expressions . (dap-ui-expressions . dap-ui--expressions-buffer))))
 
-(defconst dap-feature->mode
+(defconst dap-features->modes
   '((sessions . dap-ui-sessions-mode)
     (breakpoints . dap-ui-breakpoints-mode)
     (controls . (dap-ui-controls-mode . posframe))
@@ -1627,14 +1627,14 @@ point is set."
 (defun dap--show-feature-window (_session)
   "Show auto configured feature windows."
   (seq-doseq (feature-start-stop dap-auto-configure-features)
-    (when-let (start-stop (alist-get feature-start-stop dap-feature->start-stop))
+    (when-let (start-stop (alist-get feature-start-stop dap-features->windows))
       (funcall (car start-stop)))))
 
 (defun dap--hide-feature-window (_session)
   "Hide all debug windows when sessions are dead."
   (unless (-filter 'dap--session-running (dap--get-sessions))
     (seq-doseq (feature-start-stop dap-auto-configure-features)
-      (-when-let* ((feature-start-stop (alist-get feature-start-stop dap-feature->start-stop))
+      (-when-let* ((feature-start-stop (alist-get feature-start-stop dap-features->windows))
                    (buffer-name (symbol-value (cdr feature-start-stop))))
         (and (get-buffer buffer-name)
              (kill-buffer buffer-name))))))
@@ -1650,7 +1650,7 @@ point is set."
     (dap-mode 1)
     (dap-ui-mode 1)
     (seq-doseq (feature dap-auto-configure-features)
-      (when-let (mode (alist-get feature dap-feature->mode))
+      (when-let (mode (alist-get feature dap-features->modes))
         (if (consp mode)
             (when (require (cdr mode) nil t)
               (funcall (car mode) 1))
@@ -1661,7 +1661,7 @@ point is set."
     (dap-mode -1)
     (dap-ui-mode -1)
     (seq-doseq (feature dap-auto-configure-features)
-      (when-let (mode (alist-get feature dap-feature->mode))
+      (when-let (mode (alist-get feature dap-features->modes))
         (if (consp mode)
             (funcall (car mode) -1)
             (funcall mode -1))))

--- a/dap-mode.el
+++ b/dap-mode.el
@@ -1625,9 +1625,9 @@ point is set."
 ;; Auto configure
 
 (defun dap--show-feature-window (_session)
-  "Show auto confiured feature windows."
+  "Show auto configured feature windows."
   (seq-doseq (feature-start-stop dap-auto-configure-features)
-    (when-let ((start-stop (alist-get feature-start-stop dap-feature->start-stop)))
+    (when-let (start-stop (alist-get feature-start-stop dap-feature->start-stop))
       (funcall (car start-stop)))))
 
 (defun dap--hide-feature-window (_session)
@@ -1639,16 +1639,18 @@ point is set."
         (and (get-buffer buffer-name)
              (kill-buffer buffer-name))))))
 
+;;;###autoload
 (define-minor-mode dap-auto-configure-mode
   "Auto configure dap minor mode."
   :init-value nil
+  :global t
   :group 'dap-mode
   (cond
    (dap-auto-configure-mode
     (dap-mode 1)
     (dap-ui-mode 1)
     (seq-doseq (feature dap-auto-configure-features)
-      (when-let ((mode (alist-get feature dap-feature->mode)))
+      (when-let (mode (alist-get feature dap-feature->mode))
         (if (consp mode)
             (when (require (cdr mode) nil t)
               (funcall (car mode) 1))
@@ -1659,8 +1661,10 @@ point is set."
     (dap-mode -1)
     (dap-ui-mode -1)
     (seq-doseq (feature dap-auto-configure-features)
-      (when-let ((mode (alist-get feature dap-feature->mode)))
-        (funcall mode -1)))
+      (when-let (mode (alist-get feature dap-feature->mode))
+        (if (consp mode)
+            (funcall (car mode) -1)
+            (funcall mode -1))))
     (remove-hook 'dap-stopped-hook #'dap--show-feature-window)
     (remove-hook 'dap-terminated-hook #'dap--hide-feature-window))))
 

--- a/dap-mode.el
+++ b/dap-mode.el
@@ -143,12 +143,12 @@ The hook will be called with the session file and the new set of breakpoint loca
 (defcustom dap-auto-configure-features '(sessions locals breakpoints expressions controls tooltip)
   "Windows to auto show on debugging when in dap-ui-auto-configure-mode."
   :group 'dap-mode
-  :type '(set (const sessions)
-              (const locals)
-              (const breakpoints)
-              (const expressions)
-              (const controls)
-              (const tooltip)))
+  :type '(set (const :tag "Show sessions popup window when debugging and enable `dap-ui-sessions-mode`" sessions)
+              (const :tag "Show locals popup window when debugging" locals)
+              (const :tag "Show breakpoints popup window when debugging and enable `dap-ui-breakpoints-mode`" breakpoints)
+              (const :tag "Show expressions popup window when debugging" expressions)
+              (const :tag "Enable `dap-ui-controls-mode` with controls to manage the debug session when debugging" controls)
+              (const :tag "Enable `dap-tooltip-mode` that enables mouse hover support when debugging" tooltip)))
 
 (defconst dap-feature->start-stop
   '((sessions . (dap-ui-sessions . dap-ui--sessions-buffer))

--- a/dap-mode.el
+++ b/dap-mode.el
@@ -137,7 +137,13 @@ The hook will be called with the session file and the new set of breakpoint loca
 (defcustom dap-debug-template-configurations nil
   "Plist Template configurations for DEBUG/RUN."
   :safe #'listp
+  :group 'dap-mode
   :type '(plist))
+
+(defcustom dap-auto-configure t
+  "Whether to auto configure dap-mode and dap-ui-mode"
+  :group 'dap-mode
+  :type 'bool)
 
 (defvar dap--debug-configuration nil
   "List of the previous configuration that have been executed.")
@@ -1236,6 +1242,8 @@ before starting the debug process."
 
 (defun dap--after-initialize ()
   "After initialize handler."
+  (when dap-auto-configure
+    (dap-auto-configure-mode 1))
   (with-demoted-errors
       "Failed to load breakpoints for the current workspace with error: %S"
     (let ((breakpoints-file dap-breakpoints-file))
@@ -1597,6 +1605,27 @@ point is set."
   "Turn on function `dap-mode'."
   (interactive)
   (dap-mode t))
+
+
+
+;; Auto configure
+
+(define-minor-mode dap-auto-configure-mode
+  "Auto configure dap minor mode."
+  :init-value dap-auto-configure
+  :group 'dap-mode
+  (cond
+   (dap-auto-configure-mode
+    (dap-ui-mode 1)
+    (when (require 'posframe nil t)
+      (dap-ui-controls-mode 1))
+    (add-hook 'dap-stopped-hook #'dap-ui-show-debug-windows)
+    (add-hook 'dap-terminated-hook #'dap-ui-hide-debug-windows))
+   (t
+    (dap-ui-mode nil)
+    (dap-ui-controls-mode nil)
+    (remove-hook 'dap-stopped-hook #'dap-ui-show-debug-windows)
+    (remove-hook 'dap-terminated-hook #'dap-ui-hide-debug-windows))))
 
 (provide 'dap-mode)
 ;;; dap-mode.el ends here

--- a/dap-mode.el
+++ b/dap-mode.el
@@ -1623,7 +1623,7 @@ point is set."
     (add-hook 'dap-terminated-hook #'dap-ui-hide-debug-windows))
    (t
     (dap-ui-mode -1)
-    (dap-ui-controls-mode nil)
+    (dap-ui-controls-mode -1)
     (remove-hook 'dap-stopped-hook #'dap-ui-show-debug-windows)
     (remove-hook 'dap-terminated-hook #'dap-ui-hide-debug-windows))))
 

--- a/dap-mode.el
+++ b/dap-mode.el
@@ -1622,7 +1622,7 @@ point is set."
     (add-hook 'dap-stopped-hook #'dap-ui-show-debug-windows)
     (add-hook 'dap-terminated-hook #'dap-ui-hide-debug-windows))
    (t
-    (dap-ui-mode nil)
+    (dap-ui-mode -1)
     (dap-ui-controls-mode nil)
     (remove-hook 'dap-stopped-hook #'dap-ui-show-debug-windows)
     (remove-hook 'dap-terminated-hook #'dap-ui-hide-debug-windows))))

--- a/dap-mode.el
+++ b/dap-mode.el
@@ -1517,7 +1517,6 @@ If the current session it will be terminated."
                        (-when-let (buffer (dap--debug-session-output-buffer debug-session))
                          (kill-buffer buffer))
                        (dap--refresh-breakpoints))))
-    (message "=>%s" cleanup-fn)
     (if (not (dap--session-running debug-session))
         (funcall cleanup-fn)
       (dap--send-message (dap--make-request "disconnect"

--- a/dap-mode.el
+++ b/dap-mode.el
@@ -1624,21 +1624,6 @@ point is set."
 
 ;; Auto configure
 
-(defun dap--show-feature-window (_session)
-  "Show auto configured feature windows."
-  (seq-doseq (feature-start-stop dap-auto-configure-features)
-    (when-let (start-stop (alist-get feature-start-stop dap-features->windows))
-      (funcall (car start-stop)))))
-
-(defun dap--hide-feature-window (_session)
-  "Hide all debug windows when sessions are dead."
-  (unless (-filter 'dap--session-running (dap--get-sessions))
-    (seq-doseq (feature-start-stop dap-auto-configure-features)
-      (-when-let* ((feature-start-stop (alist-get feature-start-stop dap-features->windows))
-                   (buffer-name (symbol-value (cdr feature-start-stop))))
-        (and (get-buffer buffer-name)
-             (kill-buffer buffer-name))))))
-
 ;;;###autoload
 (define-minor-mode dap-auto-configure-mode
   "Auto configure dap minor mode."
@@ -1655,8 +1640,8 @@ point is set."
             (when (require (cdr mode) nil t)
               (funcall (car mode) 1))
             (funcall mode 1))))
-    (add-hook 'dap-stopped-hook #'dap--show-feature-window)
-    (add-hook 'dap-terminated-hook #'dap--hide-feature-window))
+    (add-hook 'dap-stopped-hook #'dap-ui-show-many-windows)
+    (add-hook 'dap-terminated-hook #'dap-ui-hide-many-windows))
    (t
     (dap-mode -1)
     (dap-ui-mode -1)
@@ -1665,8 +1650,8 @@ point is set."
         (if (consp mode)
             (funcall (car mode) -1)
             (funcall mode -1))))
-    (remove-hook 'dap-stopped-hook #'dap--show-feature-window)
-    (remove-hook 'dap-terminated-hook #'dap--hide-feature-window))))
+    (remove-hook 'dap-stopped-hook #'dap-ui-show-many-windows)
+    (remove-hook 'dap-terminated-hook #'dap-ui-hide-many-windows))))
 
 (provide 'dap-mode)
 ;;; dap-mode.el ends here

--- a/dap-mode.el
+++ b/dap-mode.el
@@ -1640,8 +1640,7 @@ point is set."
             (when (require (cdr mode) nil t)
               (funcall (car mode) 1))
             (funcall mode 1))))
-    (add-hook 'dap-stopped-hook #'dap-ui-show-many-windows)
-    (add-hook 'dap-terminated-hook #'dap-ui-hide-many-windows))
+    (dap-ui-many-windows-mode 1))
    (t
     (dap-mode -1)
     (dap-ui-mode -1)
@@ -1650,8 +1649,7 @@ point is set."
         (if (consp mode)
             (funcall (car mode) -1)
             (funcall mode -1))))
-    (remove-hook 'dap-stopped-hook #'dap-ui-show-many-windows)
-    (remove-hook 'dap-terminated-hook #'dap-ui-hide-many-windows))))
+    (dap-ui-many-windows-mode -1))))
 
 (provide 'dap-mode)
 ;;; dap-mode.el ends here

--- a/dap-ui.el
+++ b/dap-ui.el
@@ -1076,7 +1076,7 @@ DEBUG-SESSION is the debug session triggering the event."
     (define-key (kbd "C L") #'dap-ui-breakpoint-log-message)))
 
 (define-minor-mode dap-ui-breakpoints-mode
-  "UI Session list minor mode."
+  "UI Breakpoints list minor mode."
   :init-value nil
   :group dap-ui
   :keymap dap-ui-breakpoints-mode-map)
@@ -1108,6 +1108,28 @@ DEBUG-SESSION is the debug session triggering the event."
   (add-hook 'dap-stack-frame-changed-hook #'dap-ui-breakpoints--refresh)
   (add-hook 'dap-breakpoints-changed-hook #'dap-ui-breakpoints--refresh)
   (add-hook 'kill-buffer-hook 'dap-ui-breakpoints--cleanup-hooks nil t))
+
+(defun dap-ui--window-visible-p (window-name)
+  "Return whether WINDOW-NAME is visible."
+  (-> (-compose 'buffer-name 'window-buffer)
+      (-map (window-list))
+      (-contains? window-name)))
+
+(defun dap-ui-show-debug-windows (_session)
+  "Show available debug windows for SESSION."
+  (save-excursion
+    (unless (dap-ui--window-visible-p dap-ui--locals-buffer)
+      (dap-ui-locals))
+    (unless (dap-ui--window-visible-p dap-ui--sessions-buffer)
+      (dap-ui-sessions))))
+
+(defun dap-ui-hide-debug-windows (_session)
+  "Hide all debug windows when sessions are dead."
+  (unless (-filter 'dap--session-running (dap--get-sessions))
+    (and (get-buffer dap-ui--sessions-buffer)
+         (kill-buffer dap-ui--sessions-buffer))
+    (and (get-buffer dap-ui--locals-buffer)
+         (kill-buffer dap-ui--locals-buffer))))
 
 (provide 'dap-ui)
 ;;; dap-ui.el ends here

--- a/dap-ui.el
+++ b/dap-ui.el
@@ -1109,5 +1109,28 @@ DEBUG-SESSION is the debug session triggering the event."
   (add-hook 'dap-breakpoints-changed-hook #'dap-ui-breakpoints--refresh)
   (add-hook 'kill-buffer-hook 'dap-ui-breakpoints--cleanup-hooks nil t))
 
+(defun dap-ui-show-many-windows (_session)
+  "Show auto configured feature windows."
+  (dap-ui-many-windows-mode 1))
+
+(defun dap-ui-hide-many-windows (_session)
+  "Hide all debug windows when sessions are dead."
+  (dap-ui-many-windows-mode -1))
+
+(define-minor-mode dap-ui-many-windows-mode
+  "Shows/hide the windows from `dap-auto-configure-features`"
+  :global t
+  (cond
+   (dap-ui-many-windows-mode
+    (seq-doseq (feature-start-stop dap-auto-configure-features)
+      (when-let (start-stop (alist-get feature-start-stop dap-features->windows))
+        (funcall (car start-stop)))))
+   (t
+    (seq-doseq (feature-start-stop dap-auto-configure-features)
+      (-when-let* ((feature-start-stop (alist-get feature-start-stop dap-features->windows))
+                   (buffer-name (symbol-value (cdr feature-start-stop))))
+        (and (get-buffer buffer-name)
+             (kill-buffer buffer-name)))))))
+
 (provide 'dap-ui)
 ;;; dap-ui.el ends here

--- a/dap-ui.el
+++ b/dap-ui.el
@@ -1109,27 +1109,5 @@ DEBUG-SESSION is the debug session triggering the event."
   (add-hook 'dap-breakpoints-changed-hook #'dap-ui-breakpoints--refresh)
   (add-hook 'kill-buffer-hook 'dap-ui-breakpoints--cleanup-hooks nil t))
 
-(defun dap-ui--window-visible-p (window-name)
-  "Return whether WINDOW-NAME is visible."
-  (-> (-compose 'buffer-name 'window-buffer)
-      (-map (window-list))
-      (-contains? window-name)))
-
-(defun dap-ui-show-debug-windows (_session)
-  "Show available debug windows for SESSION."
-  (save-excursion
-    (unless (dap-ui--window-visible-p dap-ui--locals-buffer)
-      (dap-ui-locals))
-    (unless (dap-ui--window-visible-p dap-ui--sessions-buffer)
-      (dap-ui-sessions))))
-
-(defun dap-ui-hide-debug-windows (_session)
-  "Hide all debug windows when sessions are dead."
-  (unless (-filter 'dap--session-running (dap--get-sessions))
-    (and (get-buffer dap-ui--sessions-buffer)
-         (kill-buffer dap-ui--sessions-buffer))
-    (and (get-buffer dap-ui--locals-buffer)
-         (kill-buffer dap-ui--locals-buffer))))
-
 (provide 'dap-ui)
 ;;; dap-ui.el ends here

--- a/dap-ui.el
+++ b/dap-ui.el
@@ -1109,28 +1109,42 @@ DEBUG-SESSION is the debug session triggering the event."
   (add-hook 'dap-breakpoints-changed-hook #'dap-ui-breakpoints--refresh)
   (add-hook 'kill-buffer-hook 'dap-ui-breakpoints--cleanup-hooks nil t))
 
-(defun dap-ui-show-many-windows (_session)
+(defun dap-ui--show-many-windows (_session)
   "Show auto configured feature windows."
-  (dap-ui-many-windows-mode 1))
+  (seq-doseq (feature-start-stop dap-auto-configure-features)
+    (when-let (start-stop (alist-get feature-start-stop dap-features->windows))
+      (funcall (car start-stop)))))
 
-(defun dap-ui-hide-many-windows (_session)
+(defun dap-ui--hide-many-windows (_session)
   "Hide all debug windows when sessions are dead."
-  (dap-ui-many-windows-mode -1))
+  (seq-doseq (feature-start-stop dap-auto-configure-features)
+    (-when-let* ((feature-start-stop (alist-get feature-start-stop dap-features->windows))
+                 (buffer-name (symbol-value (cdr feature-start-stop))))
+      (and (get-buffer buffer-name)
+           (kill-buffer buffer-name)))))
+
+;;;###autoload
+(defun dap-ui-show-many-windows ()
+  "Show auto configured feature windows."
+  (interactive)
+  (dap-ui--show-many-windows nil))
+
+;;;###autoload
+(defun dap-ui-hide-many-windows ()
+  "Hide all debug windows when sessions are dead."
+  (interactive)
+  (dap-ui--hide-many-windows nil))
 
 (define-minor-mode dap-ui-many-windows-mode
   "Shows/hide the windows from `dap-auto-configure-features`"
   :global t
   (cond
    (dap-ui-many-windows-mode
-    (seq-doseq (feature-start-stop dap-auto-configure-features)
-      (when-let (start-stop (alist-get feature-start-stop dap-features->windows))
-        (funcall (car start-stop)))))
+    (add-hook 'dap-stopped-hook #'dap-ui--show-many-windows)
+    (add-hook 'dap-terminated-hook #'dap-ui--hide-many-windows))
    (t
-    (seq-doseq (feature-start-stop dap-auto-configure-features)
-      (-when-let* ((feature-start-stop (alist-get feature-start-stop dap-features->windows))
-                   (buffer-name (symbol-value (cdr feature-start-stop))))
-        (and (get-buffer buffer-name)
-             (kill-buffer buffer-name)))))))
+    (remove-hook 'dap-stopped-hook #'dap-ui--show-many-windows)
+    (remove-hook 'dap-terminated-hook #'dap-ui--hide-many-windows))))
 
 (provide 'dap-ui)
 ;;; dap-ui.el ends here

--- a/docs/page/configuration.md
+++ b/docs/page/configuration.md
@@ -3,11 +3,21 @@ Configuration
 
 ## DAP mode configuration
 
-Enable both `dap-mode` and `dap-ui-mode` (requires posframe to be
-installed manually, available only for emacs version \>= 26).
+You only need to enable `dap-mode` first with:
 
-``` elisp
+```elisp
 (dap-mode 1)
+```
+
+Enabling `dap-mode` triggers the auto-configuration by default but if you want to enable only specific modes instead, you can disable it setting `dap-auto-configure` to `nil`:
+
+```elisp
+(setq dap-mode-auto-configure nil)
+
+(dap-mode 1)
+
+;; The modes above are optional
+
 (dap-ui-mode 1)
 ;; enables mouse hover support
 (dap-tooltip-mode 1)

--- a/docs/page/configuration.md
+++ b/docs/page/configuration.md
@@ -3,17 +3,16 @@ Configuration
 
 ## DAP mode configuration
 
-You only need to enable `dap-mode` first with:
+For an auto-configuration enable the `dap-auto-configure-mode`. You can configure which features from `dap-mode` do you want with `dap-auto-configure-features`:
 
 ```elisp
-(dap-mode 1)
+;; Enabling only some features
+(setq dap-auto-configure-features '(sessions locals controls tooltip))
 ```
 
-Enabling `dap-mode` triggers the auto-configuration by default but if you want to enable only specific modes instead, you can disable it setting `dap-auto-configure` to `nil`:
+Or if you want to enable only specific modes instead:
 
 ```elisp
-(setq dap-mode-auto-configure nil)
-
 (dap-mode 1)
 
 ;; The modes above are optional

--- a/docs/page/how-to.md
+++ b/docs/page/how-to.md
@@ -1,41 +1,6 @@
 How to
 ======
 
-## Display debug windows on session startup
-
-Here it is a code that can be used to automatically display/hide debug windows.
-
-```elisp
-(defun my/window-visible (b-name)
-  "Return whether B-NAME is visible."
-  (-> (-compose 'buffer-name 'window-buffer)
-      (-map (window-list))
-      (-contains? b-name)))
-
-(defun my/show-debug-windows (session)
-  "Show debug windows."
-  (let ((lsp--cur-workspace (dap--debug-session-workspace session)))
-    (save-excursion
-      ;; display locals
-      (unless (my/window-visible dap-ui--locals-buffer)
-        (dap-ui-locals))
-      ;; display sessions
-      (unless (my/window-visible dap-ui--sessions-buffer)
-        (dap-ui-sessions)))))
-
-(add-hook 'dap-stopped-hook 'my/show-debug-windows)
-
-(defun my/hide-debug-windows (session)
-  "Hide debug windows when all debug sessions are dead."
-  (unless (-filter 'dap--session-running (dap--get-sessions))
-    (and (get-buffer dap-ui--sessions-buffer)
-         (kill-buffer dap-ui--sessions-buffer))
-    (and (get-buffer dap-ui--locals-buffer)
-         (kill-buffer dap-ui--locals-buffer))))
-
-(add-hook 'dap-terminated-hook 'my/hide-debug-windows)
-```
-
 ## Activate minor modes when stepping through code
 
 You may want to activate minor modes, e.g. `read-only-mode`, when the debugger is active in a buffer. If so, you could use a trick like this:


### PR DESCRIPTION
This adds an option to auto-configure `dap-mode` and `dap-ui-mode` to have a more "Emacs as IDE" behavior.