### PR TITLE
Make dap-ui-locals always expand nodes

### DIFF
--- a/dap-ui.el
+++ b/dap-ui.el
@@ -800,7 +800,7 @@ DEBUG-SESSION is the debug session triggering the event."
                                               (dap--cur-session)
                                               variables-reference)))
                   it)
-            (lsp-treemacs-render it " Locals " nil dap-ui--locals-buffer)
+            (lsp-treemacs-render it " Locals " t dap-ui--locals-buffer)
             (or it t))
           (lsp-treemacs-render
            '((:label "Nothing to display..."


### PR DESCRIPTION
Like VSCode, this PR makes default expand the `dap-ui-locals`

![image](https://user-images.githubusercontent.com/7820865/81762184-621e7f00-94a2-11ea-84a8-b072fcb27774.png)

![image](https://user-images.githubusercontent.com/7820865/81762220-7febe400-94a2-11ea-9171-22edf82515fd.png)

