### PR TITLE
dap-feature->modes: remove buffer local mode

### DIFF
--- a/dap-java.el
+++ b/dap-java.el
@@ -226,6 +226,8 @@ initiate `compile' and attach to the process."
   (interactive (list (dap-java--populate-default-args nil)))
   (dap-start-debugging debug-args))
 
+(defvar testng-report-directory)
+
 (defun dap-java--run-unit-test-command (runner run-method?)
   "Run debug test with the following arguments.
 RUNNER is the test executor. RUN-METHOD? when t it will try to
@@ -309,7 +311,7 @@ attaching to the test."
                     port)
             nil))))
 
-(cl-defmethod dap-handle-event ((event (eql hotcodereplace)) session _params)
+(cl-defmethod dap-handle-event ((_event (eql hotcodereplace)) session _params)
   (when (eq dap-java-hot-reload 'always)
     (-let [(&hash "changedClasses" classes) (dap-request session "redefineClasses")]
       (if classes

--- a/dap-mode.el
+++ b/dap-mode.el
@@ -157,9 +157,7 @@ The hook will be called with the session file and the new set of breakpoint loca
     (expressions . (dap-ui-expressions . dap-ui--expressions-buffer))))
 
 (defconst dap-features->modes
-  '((sessions . dap-ui-sessions-mode)
-    (breakpoints . dap-ui-breakpoints-mode)
-    (controls . (dap-ui-controls-mode . posframe))
+  '((controls . (dap-ui-controls-mode . posframe))
     (tooltip . dap-tooltip-mode)))
 
 (defvar dap--debug-configuration nil
@@ -1154,8 +1152,9 @@ RESULT to use for the callback."
                                                         stack-frames
                                                         (-lambda ((frame &as &hash "name"))
                                                           (if-let (frame-path (dap--get-path-for-frame frame))
-                                                              (format "%s: %s (in %s)" (incf index) name frame-path)
-                                                            (format "%s: %s" (incf index) name)))
+                                                              (format "%s: %s (in %s)"
+                                                                      (cl-incf index) name frame-path)
+                                                            (format "%s: %s" (cl-incf index) name)))
                                                         nil
                                                         t)))
             (dap--go-to-stack-frame (dap--cur-session) new-stack-frame))

--- a/dap-ui.el
+++ b/dap-ui.el
@@ -476,6 +476,8 @@ DEBUG-SESSION is the debug session triggering the event."
 
 (declare-function posframe-show "ext:posframe")
 (declare-function posframe-hide "ext:posframe")
+(declare-function posframe-poshandler-frame-top-center "ext:posframe")
+(defvar posframe-mouse-banish)
 
 (defun dap-ui--update-controls (&rest _)
   (let* ((session (dap--cur-session))
@@ -507,13 +509,14 @@ DEBUG-SESSION is the debug session triggering the event."
                         (dap-ui--create-command "disconnect.png" #'dap-disconnect "Disconnect")
                         " "
                         (dap-ui--create-command "restart.png" #'dap-debug-restart "Restart")))
-              (posframe-mouse-banish nil)
+              posframe-mouse-banish
               (pos-frame (-first
                           (lambda (frame)
                             (let ((buffer-info (frame-parameter frame 'posframe-buffer)))
                               (or (equal dap-ui--control-buffer (car buffer-info))
                                   (equal dap-ui--control-buffer (cdr buffer-info)))))
                           (frame-list))))
+          (ignore posframe-mouse-banish)
           (when (eq (selected-frame) pos-frame)
             (select-frame (frame-parent pos-frame)))
           (posframe-show dap-ui--control-buffer


### PR DESCRIPTION
`dap-ui-sessions-mode` and `dap-ui-breakpoints-mode` are local mode that should only be enabled in special buffer, right now we enabled it together with `dap-auto-configure-mode`, which cause wrong mode and key bindings enabled in edit buffer. We should fix that.
One example is enabled `dap-auto-configure-mode` in `*scratch*` buffer, and we cannot type `D` anymore, since it's interfere with `dap-ui-breakpoints-mode` key bindings.

Also, fix several byte compile warnings.
