### PR TITLE
dap-mode-line: dont display when failed or terminated

### DIFF
--- a/dap-mode.el
+++ b/dap-mode.el
@@ -1274,10 +1274,12 @@ before starting the debug process."
 (defun dap-mode-line ()
   "Calculate DAP modeline."
   (when lsp-mode
-    (-when-let (debug-session (dap--cur-session))
-      (format " %s - %s"
-              (dap--debug-session-name debug-session)
-              (dap--debug-session-state debug-session)))))
+    (-when-let* ((debug-session (dap--cur-session))
+                 (state (dap--debug-session-state debug-session)))
+      (unless (member state '(failed terminated))
+        (format " %s - %s"
+                (dap--debug-session-name debug-session)
+                (dap--debug-session-state debug-session))))))
 
 (defun dap--thread-label (debug-session thread)
   "Calculate thread name for THREAD from DEBUG-SESSION."


### PR DESCRIPTION
Display `dap-mode-line` even after the session is failed or terminated is a huge waste on `mode-line` area. We should only display it when the debugger is running.
![image](https://user-images.githubusercontent.com/2631472/82978144-cd2d9100-a01e-11ea-813b-2168fd5c9d19.png)
And hide it when it's terminated/failed.
![image](https://user-images.githubusercontent.com/2631472/82978183-e6364200-a01e-11ea-8be3-ba8210f39ac0.png)

