### PR TITLE
Update  dap-python for running in pipenv

### DIFF
--- a/dap-python.el
+++ b/dap-python.el
@@ -273,7 +273,6 @@ as the pyenv version then also return nil. This works around https://github.com/
 			     (list :type "python-test-at-point"
 				   :args ""
 				   :module "pytest"
-				   :virtualenv "pyenv"
 				   :request "launch"
 				   :virtualenv "pyenv"
 				   :name "Python :: Run pytest (at point)"))

--- a/dap-python.el
+++ b/dap-python.el
@@ -265,7 +265,7 @@ as the pyenv version then also return nil. This works around https://github.com/
                                    :program nil
                                    :module "pytest"
                                    :request "launch"
-				   :virtualenv "pyenv"
+				     :virtualenv "pyenv"
                                    :name "Python :: Run pytest (buffer)"))
 
 (dap-register-debug-provider "python-test-at-point" 'dap-python--populate-test-at-point)

--- a/dap-python.el
+++ b/dap-python.el
@@ -193,9 +193,9 @@ as the pyenv version then also return nil. This works around https://github.com/
          (debug-port (dap--find-available-port))
 	 (virtualenv-type (plist-get conf :virtualenv))
          (python-executable 
-	  (cond ((= virtualenv-type "pyenv")
+	  (cond ((string= virtualenv-type "pyenv")
 		 (dap-python--pyenv-executable-find dap-python-executable))
-		((= virtualenv-type "pipenv")
+		((string= virtualenv-type "pipenv")
 		 (dap-python--pipenv-executable-find dap-python-executable))
 		(t
 		 (executable-find dap-python-executable))))

--- a/dap-python.el
+++ b/dap-python.el
@@ -255,7 +255,7 @@ as the pyenv version then also return nil. This works around https://github.com/
                                    :module nil
                                    :program nil
                                    :request "launch"
-				   :virtualenv "pyenv"
+				     :virtualenv "pyenv"
                                    :name "Python :: Run file (buffer)"))
 
 (dap-register-debug-template "Python :: Run pytest (buffer)"


### PR DESCRIPTION
We have many options for executing the python program.
At first, I want to add "pipenv" into the option.