### PR TITLE
Add an always prompting version of dap-ui-expressions-add

### DIFF
--- a/dap-ui.el
+++ b/dap-ui.el
@@ -870,6 +870,11 @@ DEBUG-SESSION is the debug session triggering the event."
   (dap-ui-expressions)
   (dap-ui-expressions-refresh))
 
+(defun dap-ui-expressions-add-prompt (expression)
+  "Prompts for an expression and adds it to `dap-ui-expressions'."
+  (interactive (list (read-string "Add watch expression: ")))
+  (dap-ui-expressions-add expression))
+
 (defun dap-ui-expressions-remove (expression)
   (interactive (list (completing-read
                       "Select expression to remove: "


### PR DESCRIPTION
I found myself wanting a function that always prompts for an expression to add. dap-ui-expressions-add uses either the selected text, or (thing-at-point), but never prompts. dap-ui-expressions-add-prompt always prompts the user if called interactively.