### PR TITLE
Extend dap-debug-restart to allow deleting the old session

### DIFF
--- a/dap-mode.el
+++ b/dap-mode.el
@@ -684,11 +684,9 @@ the list of debug sessions."
       (progn
         (when (dap--session-running debug-session)
           (message "Disconnecting from %s" (dap--debug-session-name debug-session))
-          (dap-disconnect debug-session)
-          (when delete-session
-            (lsp-workspace-set-metadata
-             "debug-sessions"
-             (cdr (lsp-workspace-get-metadata "debug-sessions")))))
+          (if delete-session
+              (dap-delete-session debug-session)
+            (dap-disconnect debug-session)))
         (dap-debug (dap--debug-session-launch-args debug-session)))
     (user-error "There is session to restart")))
 


### PR DESCRIPTION
Extend dap-debug-restart to take an optional argument (in interactive mode it is
the prefix argument) that, if set, causes the old session to be deleted.

The user can now, for example, just press C-u M-x dap-debug-restart, and the old session will be deleted. (For spacemacs+evil users it's SPC u M-x dap-debug-restart.)