### PR TITLE
Fix watch expression when using with code-debug

### DIFF
--- a/dap-mode.el
+++ b/dap-mode.el
@@ -1151,7 +1151,8 @@ RESULT to use for the callback."
         (dap--send-message
          (dap--make-request "evaluate"
                             (list :expression expression
-                                  :frameId active-frame-id))
+                                  :frameId active-frame-id
+                                  :context "hover"))
          (-lambda ((&hash "success" "message" "body"))
            (dap-overlays--display-interactive-eval-result
             (if success (gethash "result" body) message)

--- a/dap-mouse.el
+++ b/dap-mouse.el
@@ -190,7 +190,8 @@ This function must return nil if it doesn't handle EVENT."
         (dap--send-message
          (dap--make-request "evaluate"
                             (list :expression expression
-                                  :frameId active-frame-id))
+                                  :frameId active-frame-id
+                                  :context "hover"))
          (-lambda ((&hash "message" "body" (var &as &hash? "result")))
            (when (= request-id dap-tooltip--request)
              (if result

--- a/dap-ui-repl.el
+++ b/dap-ui-repl.el
@@ -65,7 +65,8 @@ INPUT is the current input."
         (dap--send-message
          (dap--make-request "evaluate"
                             (list :expression input
-                                  :frameId active-frame-id))
+                                  :frameId active-frame-id
+                                  :context "repl"))
          (-lambda ((&hash "success" "message" "body"))
            (-when-let (buffer (get-buffer dap-ui--repl-buffer))
              (with-current-buffer buffer

--- a/dap-ui.el
+++ b/dap-ui.el
@@ -914,7 +914,8 @@ DEBUG-SESSION is the debug session triggering the event."
                             (dap--cur-session)
                             "evaluate"
                             :expression expression
-                            :frameId active-frame-id)]
+                            :frameId active-frame-id
+                            :context "watch")]
                       `(:key ,expression
                              :expression ,expression
                              :label ,(concat (propertize (format "%s: " expression) 'face 'font-lock-variable-name-face)


### PR DESCRIPTION
watch expression doesn't work with code-debug. Looking at its [source code](https://github.com/WebFreak001/code-debug/blob/f2923480e45874324ca94badbe35c7ed80a5e172/src/mibase.ts#L622), it seems code-debug expects evaluateRequest's arg.context to be either "watch" or 'hover". Otherwise, it will assume "repl" context and pass the expression as is to gdb, resulting in error. I don't know who's at fault here. Anyway, here's the change that would make watch expression work.

