### PR TITLE
Implement :console "integratedTerminal"/"externalTerminal"

### DIFF
--- a/dap-mode.el
+++ b/dap-mode.el
@@ -78,7 +78,7 @@ should be used in `dap-internal-terminal-*'."
     (declare-function vterm-mode "vterm" (&optional arg))
     (let ((vterm-shell command)
           (vterm-kill-buffer-on-exit nil))
-      (vterm-mode 1)
+      (vterm-mode)
       ;; TODO: integrate into dap-ui
       (display-buffer (current-buffer)))))
 
@@ -90,7 +90,9 @@ should be used in `dap-internal-terminal-*'."
   "Run COMMAND with an auto-detected terminal.
 If `vterm' is loaded or auto-loaded, use vterm. Otherwise, use
 `async-shell-command'."
-  (if (fboundp 'vterm-mode)
+  ;; NOTE: 'vterm is autoloaded. This means that (fboundp 'vterm) will yield t
+  ;; even before vterm is loaded.
+  (if (fboundp 'vterm)
       (dap-internal-terminal-vterm command title debug-session)
     (dap-internal-terminal-shell command title debug-session)))
 

--- a/dap-mode.el
+++ b/dap-mode.el
@@ -988,7 +988,9 @@ PARAMS are the event params.")
      (when (string= kind "external")
        (let* ((name (or title (concat (dap--debug-session-name debug-session)
                                       "- terminal"))))
-         (with-demoted-errors "dap-debug: failed to start external terminal: %s"
+         (with-demoted-errors "dap-debug: failed to start \
+external terminal: %s. Set `dap-external-terminal' to the correct
+value or install the terminal configured (probably xterm)."
            (apply #'start-process name name
                   (-map (lambda (part)
                           (->> part

--- a/dap-mode.el
+++ b/dap-mode.el
@@ -48,7 +48,7 @@
   :group 'dap-mode
   :type 'boolean)
 
-(defcustom dap-external-terminal '("xterm" "-display" "{title}"
+(defcustom dap-external-terminal '("xterm" "-T" "{title}"
                                    "-hold" "-e" "sh" "-c" "exec {command}")
   "Command to launch the external terminal for debugging.
 When specifying that the program be run in an external terminal,

--- a/dap-mode.el
+++ b/dap-mode.el
@@ -926,15 +926,7 @@ PARAMS are the event params.")
                                                         debug-session
                                                         (gethash "command" parsed-msg)))
                                 (message "Unable to find handler for %s." (pp parsed-msg))))
-                  ("request" (-let* (((&hash "arguments"
-                                             (&hash? "args" "cwd")
-                                             "seq" "command")
-                                      parsed-msg)
-                                     (default-directory cwd))
-                               (async-shell-command (s-join " " args))
-                               (dap--send-message (dap--make-response seq command)
-                                                  (dap--resp-handler)
-                                                  debug-session))))))
+                  ("request" (dap--start-process debug-session parsed-msg)))))
             (dap--parser-read parser msg)))))
 
 (defun dap--create-output-buffer (session-name)


### PR DESCRIPTION
Note especially the breaking change to `dap--make-response'' api. I have grepped the codebase for references to that function and didn't find any, however there may be third party plugins (official?). The only place in the dap protocol where the *client* gets to make a response is with "runInTerminal".