### PR TITLE
[dap-lldb] Change :type to lldb-vscode, per the docs

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -2,6 +2,8 @@
 #+STARTUP: content
 
 * Changelog
+** 0.7
+   - [Breaking change] For ~dap-lldb.el~, change ~type~ to ~lldb-vscode~.
 ** 0.5
    - added support for running TestNG tests
    - added ~dap-auto-configure-mode~ as the new ~dap-mode~ integration point.

--- a/dap-lldb.el
+++ b/dap-lldb.el
@@ -43,7 +43,7 @@
   "Populate CONF with the required arguments."
   (-> conf
       (dap--put-if-absent :dap-server-path dap-lldb-debug-program)
-      (dap--put-if-absent :type "lldb")
+      (dap--put-if-absent :type "lldb-vscode")
       (dap--put-if-absent :cwd default-directory)
       (dap--put-if-absent :program (if (commandp dap-lldb-debugged-program-function)
                                        (call-interactively dap-lldb-debugged-program-function)
@@ -52,9 +52,9 @@
 
 (eval-after-load "dap-mode"
   '(progn
-     (dap-register-debug-provider "lldb" 'dap-lldb--populate-start-file-args)
-     (dap-register-debug-template "LLDB Run Configuration"
-                             (list :type "lldb"
+     (dap-register-debug-provider "lldb-vscode" 'dap-lldb--populate-start-file-args)
+     (dap-register-debug-template "LLDB (VS Code) :: Run Configuration"
+                             (list :type "lldb-vscode"
                                    :cwd nil
                                    :request "launch"
                                    :program nil


### PR DESCRIPTION
The documentation says that the :type for both 'attach' and 'launch'
requests must be 'lldb-vscode'. (though it appears to work even when
the :type is wrong...)

An added benefit is that we no longer have any naming conflicts with
the dap-gdb-lldb's lldb debug adapter, which has :type 'lldb'.


----

#