### PR TITLE
Strip trailing comments from launch.json

### DIFF
--- a/dap-launch.el
+++ b/dap-launch.el
@@ -41,7 +41,7 @@ supported."
                 (or (: "//" (* nonl) eol)
                     (: "/*" (* (or (not (any ?*))
                                    (: (+ ?*) (not (any ?/))))) (+ ?*) ?/)
-                    (: "," (group (* (any blank ?\C-j)) (any ?\} ?\] )))))
+                    (: "," (group (* (any blank ?\C-j)) (any ?\} ?\])))))
                (: "\"" (* (or (not (any ?\\ ?\")) (: ?\\ nonl))) "\"")))
           nil t)
     ;; we matched a comment

--- a/dap-launch.el
+++ b/dap-launch.el
@@ -28,7 +28,7 @@
 (require 'f)
 (require 'rx)
 
-(defun dap-launch-sanitize-json()
+(defun dap-launch-sanitize-json ()
   "Remove all C-style comments and trailing commas in the current buffer.
 Comments in strings are ignored. The buffer is modified in place.
 Replacement starts at point, and strings before it are ignored,

--- a/test/dap-test.el
+++ b/test/dap-test.el
@@ -148,7 +148,7 @@
 \"/*string*/\""))))
 
 (ert-deftest dap-launch-test--delete-commas ()
-  (let ((orig "{
+  (let* ((orig "{
   \"abc\": 123,
 }")
         (post-exp (dap-launch-test--sanitize-json orig)))


### PR DESCRIPTION
We already sanitize comments from JSON.  Let's also strip trailing commas.  I happen to have launch.json with trailing commas, which is out of my control at my workplace.  Furthermore, VSCode happily ingests these trailing newlines in the "JSON" launch configuration.  Emacs' DAP-mode should handle such "JSON" as well.

The regex works by finding any commas, followed any number of whitespace or newlines, followed by a closing brace or bracket.  The non-comma characters are placed in a separate regex group (2), so that they can replace the full match and only strip the comma itself.

With a file like the following
```
{
    // Use IntelliSense to learn about possible attributes.
    // Hover to view descriptions of existing attributes.
    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
    "version": "0.2.0",
    "configurations": [
        {
            "type": "hhvm",
            "request": "attach",
            "name": "Attach to HHVM",
            "disableStdoutRedirection": false
        },
        {
            "type": "hhvm",
            "request": "launch",
            "name": "Launch Script",
            "launchScriptPath": "${file}",
        },
        {
            "type": "hhvm",
            "request": "launch",
            "name": "Launch Script Controller",
            "launchScriptPath": "${fileBasename}",
            "launchWrapperCommand": "${workspaceFolder}/scripts/init",
        },
	/* some silly comment */
    ],
}
```

We get the following diff
```
2,4c2,4
<     // Use IntelliSense to learn about possible attributes.
<     // Hover to view descriptions of existing attributes.
<     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
---
>
>
>
17c17
<             "launchScriptPath": "${file}",
---
>             "launchScriptPath": "${file}"
24c24
<             "launchWrapperCommand": "${workspaceFolder}/scripts/init",
---
>             "launchWrapperCommand": "${workspaceFolder}/scripts/init"
26,27c26,27
< 	/* some silly comment */
<     ],
---
>
>     ]
```

resulting in
```
{



    "version": "0.2.0",
    "configurations": [
        {
            "type": "hhvm",
            "request": "attach",
            "name": "Attach to HHVM",
            "disableStdoutRedirection": false
        },
        {
            "type": "hhvm",
            "request": "launch",
            "name": "Launch Script",
            "launchScriptPath": "${file}"
        },
        {
            "type": "hhvm",
            "request": "launch",
            "name": "Launch Script Controller",
            "launchScriptPath": "${fileBasename}",
            "launchWrapperCommand": "${workspaceFolder}/scripts/init"
        },

    ]
}
```