### PR TITLE
Improve the "trailing-comma" regex

### DIFF
--- a/dap-launch.el
+++ b/dap-launch.el
@@ -41,7 +41,8 @@ supported."
                 (or (: "//" (* nonl) eol)
                     (: "/*" (* (or (not (any ?*))
                                    (: (+ ?*) (not (any ?/))))) (+ ?*) ?/)
-                    (: "," (group (* (any blank ?\C-j)) (any ?\} ?\])))))
+                    (: "," (group (* (any blank space ?\v ?\u2028 ?\u2029))
+                                  (any ?\} ?\])))))
                (: "\"" (* (or (not (any ?\\ ?\")) (: ?\\ nonl))) "\"")))
           nil t)
     ;; we matched a comment

--- a/test/dap-test.el
+++ b/test/dap-test.el
@@ -149,12 +149,26 @@
 
 (ert-deftest dap-launch-test--delete-commas ()
   (let* ((orig "{
-  \"abc\": 123,
+    \"conf\": [
+        {
+          \"a\": \"b\",\t\v\u00A0
+        },
+        {
+          \"b\": \"c\",\xD\u2028\u2029
+        },\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006
+    ],\u2007\u2008\u2009\u200A\u202F\u205F\u3000
 }")
-        (post-exp (dap-launch-test--sanitize-json orig)))
-    (should (string= post-exp "{
-  \"abc\": 123
-}"))))
+         (expected "{
+    \"conf\": [
+        {
+          \"a\": \"b\"\t\v\u00A0
+        },
+        {
+          \"b\": \"c\"\xD\u2028\u2029
+        }\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006
+    ]\u2007\u2008\u2009\u200A\u202F\u205F\u3000
+}"))
+    (should (string= (dap-launch-test--sanitize-json orig) expected))))
 
 (ert-deftest dap-launch-test--comment-in-string ()
   (let ((orig "\"// orig\""))


### PR DESCRIPTION
The old regex was missing a significant number of legitimate spaces per the JSON spec: https://spec.json5.org/#white-space.  In effect this meant, we wouldn't strip trailing commas that were followed by these valid characters.  Make the regex exhaustive.

I'm sprinkling all the relevant space characters in the tests as defined by the spec to ensure our regex catches them all.

NOTE: if you try manually testing `dap-launch-sanitize-json` in `json-mode` or `js-mode`, you're gonna have a bad time.  Test this stuff in `fundamental-mode` if you find yourself so inclined...