### PR TITLE
dap-python: Support attach mode

### DIFF
--- a/docs/page/configuration.md
+++ b/docs/page/configuration.md
@@ -109,6 +109,31 @@ settings.
             :name "My App"))
     ```
 
+    `dap-python` supports also the "attach" mode to attach and debug a long running script.
+    A template named "Python :: Attach to running process" is also pre-registered for this purpose.
+    ```elisp
+    (dap-register-debug-template "Python :: Attach to running process"
+      (list :type "python"
+            :request "attach"
+            :processId "${command:pickProcess}"
+            :name "Python :: Attach to running process"))
+    ```
+    The `${command:pickProcess}` configuration variable used by default to facilitate the user
+    selecting the debug process by a completion popping up window. The real `processId` can
+    always be specified using its *pid*.
+
+    **Note**: on Linux this is achieved using the [ptrace syscall](https://www.man7.org/linux/man-pages/man2/ptrace.2.html "ptrace syscall man page")
+    wrapped inside the gdb tool. Which mean below additional steps are also need to be done as well:
+      - Install GDB.
+      - Turn on classic ptrace permission
+        ```bash
+        sudo sh -c 'echo 0 > /proc/sys/kernel/yama/ptrace_scope'
+        ```
+        Or starting the debugger under root user
+        ```elisp
+        setq dap-python-terminal "sudo "
+        ```
+
 ## Ruby
 
   - Download and extract [VSCode Ruby


### PR DESCRIPTION
- New configuration attribute `processId` is added.
  This name is picked to provide a consistent interface for both debugpy
  and ptvsd as well as make it works with launch.json naturally.