### PR TITLE
Use eval-and-compile for `dash-expand:&dap-session'

### DIFF
--- a/dap-mode.el
+++ b/dap-mode.el
@@ -243,7 +243,7 @@ The hook will be called with the session file and the new set of breakpoint loca
 (defvar dap-connect-retry-interval 0.02
   "Retry interval for dap connect.")
 
-(eval-when-compile
+(eval-and-compile
   (defun dash-expand:&dap-session (key source)
     `(,(intern-soft (format "dap--debug-session-%s" (eval key))) ,source)))
 


### PR DESCRIPTION
I'm using gccemacs with Straight.el. I noticed that this

``` emacs-lisp
    -lambda ((session &as &dap-session 'name 'thread-states))
```

expanded to something like

``` emacs-lisp
     (session input0)
      (--dash-source-1018-- session)
      (&dap-session
       (car-safe
        (prog1 --dash-source-1018--
          (setq --dash-source-1018--
                (cdr --dash-source-1018--)))))
      (--dash-source-1019--
       (car-safe
        (prog1 --dash-source-1018--
          (setq --dash-source-1018--
                (cdr --dash-source-1018--)))))
```

which doesn't make sense.

Using `eval-and-compile` seems to make it expand to what we would expect.