### PR TITLE
Update CI badge.

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,7 +1,7 @@
 [[https://melpa.org/#/dap-mode][file:https://melpa.org/packages/dap-mode-badge.svg]]
 [[https://stable.melpa.org/#/dap-mode][file:https://stable.melpa.org/packages/dap-mode-badge.svg]]
 [[http://spacemacs.org][file:https://cdn.rawgit.com/syl20bnr/spacemacs/442d025779da2f62fc86c2082703697714db6514/assets/spacemacs-badge.svg]]
-[[https://travis-ci.org/emacs-lsp/dap-mode][file:https://travis-ci.org/emacs-lsp/dap-mode.svg]]
+[[https://github.com/emacs-lsp/dap-mode/actions][file:https://github.com/emacs-lsp/dap-mode/workflows/CI/badge.svg]]
 
 * dap-mode
 ** Table of Contents :TOC_4_gh:noexport:


### PR DESCRIPTION
I think the CI has moved from `Travis CI` to `GitHub actions`?