### PR TITLE
Fix `dap-variables-find-vscode-config`

### DIFF
--- a/dap-variables.el
+++ b/dap-variables.el
@@ -506,7 +506,7 @@ for F in either ROOT/ or ROOT/.vscode/."
   (let* ((root (file-name-as-directory root))
          (root-f (concat root f))
          (root-vscode (concat root (file-name-as-directory ".vscode") f)))
-    (cl-some #'file-exists-p (list root-f root-vscode))))
+    (seq-find #'file-exists-p (list root-f root-vscode))))
 
 (defconst dap-variables-os-property-alist
   '((windows-nt . :windows)


### PR DESCRIPTION
I recently hit this issue when trying to launch `dap-debug`.  Attempting to read from `.vscode` hit errors when trying to read the value `t`.  Instead of returning `t` when a file exists, return the actual file.

https://github.com/emacs-lsp/dap-mode/commit/9ad62ea562f3651bda3f6adb94d3274811147ec9#r43781039