### PR TITLE
Add ui-display-frame to dap--debug-session struct

### DIFF
--- a/dap-mode.el
+++ b/dap-mode.el
@@ -264,6 +264,7 @@ The hook will be called with the session file and the new set of breakpoint loca
   (workspace nil)
   (threads nil)
   (thread-states (make-hash-table :test 'eql) :read-only t)
+  (ui-display-frame nil)
   (active-frame-id nil)
   (active-frame nil)
   (cursor-marker nil)
@@ -1457,7 +1458,8 @@ DEBUG-SESSIONS - list of the currently active sessions."
       (--each (dap--buffer-list) (with-current-buffer it
                                    (->> breakpoints
                                         (gethash buffer-file-name)
-                                        (dap--set-breakpoints-in-file buffer-file-name))))))
+                                        (dap--set-breakpoints-in-file buffer-file-name)))))
+    (setf (dap--debug-session-ui-display-frame new-session) (selected-frame)))
 
   (run-hook-with-args 'dap-session-changed-hook lsp--cur-workspace)
 
@@ -1599,6 +1601,7 @@ before starting the debug process."
     (unless skip-debug-session
       (let ((debug-session (dap--create-session launch-args)))
         (setf (dap--debug-session-program-proc debug-session) program-process)
+        (setf (dap--debug-session-ui-display-frame debug-session) (selected-frame))
         (dap--send-message
          (dap--initialize-message type)
          (dap--session-init-resp-handler

--- a/dap-ui.el
+++ b/dap-ui.el
@@ -355,16 +355,17 @@ DEBUG-SESSION is the debug session triggering the event."
 
 (defun dap-ui--show-buffer (buf)
   "Show BUF according to defined rules."
-  (when-let (win (display-buffer-in-side-window buf
-                                                (or (-> buf
-                                                        buffer-name
-                                                        (assoc dap-ui-buffer-configurations)
-                                                        cl-rest)
-                                                    '((side . right)
-                                                      (slot . 1)
-                                                      (window-width . 0.20)))))
-    (set-window-dedicated-p win t)
-    (select-window win)))
+  (with-selected-frame (dap--debug-session-ui-display-frame (dap--cur-session))
+    (when-let (win (display-buffer-in-side-window buf
+                                                  (or (-> buf
+                                                          buffer-name
+                                                          (assoc dap-ui-buffer-configurations)
+                                                          cl-rest)
+                                                      '((side . right)
+                                                        (slot . 1)
+                                                        (window-width . 0.20)))))
+      (set-window-dedicated-p win t)
+      (select-window win))))
 
 
 ;; breakpoints


### PR DESCRIPTION
Regarding issue #402.

Prior to this, when the debugger stops (e.g. breakpoint), it
spawns the ui elements in whatever is `(current-frame)`.  This changes
so that the UI display frame is set when the user starts or switches
to a session.

In particular the prior functionality is a bug for `exwm` users
debugging a program that produces a floating graphical window, which
will be contained in an Emacs frame under `exwm`.  Often a breakpoint
would be triggered by user interaction so that frame has focus.

