### PR TITLE
`dap-start-debugging-noexpand': expand :cwd

### DIFF
--- a/dap-chrome.el
+++ b/dap-chrome.el
@@ -50,7 +50,7 @@
   (setq conf (-> conf
                  (plist-put :type "chrome")
                  (plist-put :dap-server-path dap-chrome-debug-program)
-                 (dap--put-if-absent :cwd (expand-file-name default-directory))))
+                 (dap--put-if-absent :cwd default-directory)))
   (dap--plist-delete
    (pcase (plist-get conf :mode)
      ("url" (-> conf

--- a/dap-mode.el
+++ b/dap-mode.el
@@ -1590,7 +1590,8 @@ before starting the debug process."
                    :wait-for-port :type :request :port
                    :startup-function :environment-variables :hostName host) launch-args)
           (session-name (dap--calculate-unique-name name (dap--get-sessions)))
-          (default-directory (or cwd default-directory))
+          (default-directory (or (and cwd (expand-file-name cwd))
+                                 default-directory))
           (process-environment (if environment-variables
                                    (cl-copy-list process-environment)
                                  process-environment))


### PR DESCRIPTION
In a previous commit, :cwd was expanded specifically in `dap-chrome`. Undo that,
and centralize expanding :cwd in `dap-start-debugging-noexpand`. This allows
:cwd to be a relative path.

Fixes #413.