### PR TITLE
Added rust specific example setting

### DIFF
--- a/docs/page/configuration.md
+++ b/docs/page/configuration.md
@@ -240,6 +240,19 @@ Using <https://github.com/WebFreak001/code-debug>
 
     Then do `dap-debug` or `dap-debug-edit-template` and selet GBD or
     LLDB configuration.
+    
+### Rust
+To fully support rust and pretty printing of strings when debugging, remember to add set `gdbpath` to `rust-gdb` in your debug template. An example template would be
+
+```elisp
+(dap-register-debug-template "Rust::GDB Run Configuration"
+                             (list :type "gdb"
+                                   :request "launch"
+                                   :name "GDB::Run"
+                		   :gdbpath "rust-gdb"
+                                   :target nil
+                                   :cwd nil))
+```
 
 ## Go
 


### PR DESCRIPTION
I have added an update for rust. Rust strings is not built up around end escaping strings with \0. There for a native debugger like GDB will not show strings correctly in the Locals area when stepping through a debugging session. Rust has a tool for this which is basically some python formatters wrapped around gdb. All this is shipped with the rust toolchain when installing rust, so rust-gdb is on the PATH and ready to be called.

This brings me to my update of the configuration: add a gdbpath that tells the debugger to use rust-gdb instead of the plain version of gdb.

I have added this configuration so others can enjoy using dap mode while coding rust.