### PR TITLE
Specify window to resize rather than relying on the current window

### DIFF
--- a/dap-mode.el
+++ b/dap-mode.el
@@ -1727,7 +1727,7 @@ normally with `dap-debug'"
               `((side . bottom) (slot . 5) (window-width . 0.20)))))
     (set-window-dedicated-p win t)
     (unless no-select (select-window win))
-    (fit-window-to-buffer nil dap-output-window-max-height dap-output-window-min-height)))
+    (fit-window-to-buffer win dap-output-window-max-height dap-output-window-min-height)))
 
 (defun dap-delete-session (debug-session)
   "Remove DEBUG-SESSION.


### PR DESCRIPTION
When the `no-select` option is passed to `dap-go-to-output-buffer` the default window isn't changed (it is not set to the window containing the output buffer). This PR explicitly resizes the window with the output buffer even when the default window remains set to something else.