### PR TITLE
Added the ability to update debugger and remove the oldest

### DIFF
--- a/dap-utils.el
+++ b/dap-utils.el
@@ -142,7 +142,7 @@ With prefix, FORCED to redownload the extension." extension-name)))
 PUBLISHER is the vscode extension publisher.
 NAME is the vscode extension name.
 VERSION is the version to update to
-PATH is the location of directory that contains the debugger. It shoul end with the version number"
+PATH is the download destination dir.
   (let* ((extension-name (concat publisher "." name))
 	 (constructed-path (f-join dap-utils-extension-path
 			   "vscode"

--- a/dap-utils.el
+++ b/dap-utils.el
@@ -137,7 +137,7 @@ With prefix, FORCED to redownload the extension." extension-name)))
          (message "%s: %s debug extension are not set. You can download it with M-x %s-setup"
                   ,dapfile ,extension-name ,dapfile)))))
 
-(defmacro dap-utils-vscode-update-function (dapfile publisher name version &optional path callback)
+(defmacro dap-utils-vscode-update-function (dapfile publisher name version &optional path)
   "Helper to create DAPFILE update function for vscode debug extension.
 PUBLISHER is the vscode extension publisher.
 NAME is the vscode extension name.

--- a/dap-utils.el
+++ b/dap-utils.el
@@ -142,7 +142,7 @@ With prefix, FORCED to redownload the extension." extension-name)))
 PUBLISHER is the vscode extension publisher.
 NAME is the vscode extension name.
 VERSION is the version to update to
-PATH is the download destination dir.
+PATH is the download destination dir."
   (let* ((extension-name (concat publisher "." name))
 	 (constructed-path (f-join dap-utils-extension-path
 			   "vscode"

--- a/dap-utils.el
+++ b/dap-utils.el
@@ -137,7 +137,7 @@ With prefix, FORCED to redownload the extension." extension-name)))
          (message "%s: %s debug extension are not set. You can download it with M-x %s-setup"
                   ,dapfile ,extension-name ,dapfile)))))
 
-(defmacro dap-utils-vscode-update-function (dapfile publisher name version &optional path)
+(defmacro dap-utils-vscode-update-function (dapfile publisher name version &optional path callback)
   "Helper to create DAPFILE update function for vscode debug extension.
 PUBLISHER is the vscode extension publisher.
 NAME is the vscode extension name.
@@ -171,7 +171,9 @@ PATH is the location of directory that contains the debugger. It shoul end with 
 	       (message "Deleting version %s", installed-version)
 	   (message "Debug extension not installed, run M-x %s-setup to install V%s"
 		    ,dapfile
-		    ,version))))))
+		    ,version)))
+       (when ,callback
+	 (funcall ,callback)))))
 
 (provide 'dap-utils)
 ;;; dap-utils.el ends here

--- a/dap-utils.el
+++ b/dap-utils.el
@@ -142,7 +142,7 @@ With prefix, FORCED to redownload the extension." extension-name)))
 PUBLISHER is the vscode extension publisher.
 NAME is the vscode extension name.
 VERSION is the version to update to
-PATH is the location of directory that contains the dir named after the version. ex: ~/.emacs.d/.extention/vscond/foo.bar/ and should never contains the version number in it"
+PATH is the location of directory that contains the debugger"
   (let* ((extension-name (concat publisher "." name))
 	 (dest (or path
 		   (f-join dap-utils-extension-path
@@ -151,21 +151,19 @@ PATH is the location of directory that contains the dir named after the version.
 	 (help-string (format "Updating %s to version %s"
 			      name
 			      version))
-	 (installed-version (car (directory-files dest
-						  nil
-						  "[[:digit:]]"
-						  t))))
+	 (installed-version (car (directory-files path nil "[[:digit:]]" t))))
     `(progn
        (defun ,(intern (format "%s-update" dapfile)) ()
 	 ,help-string
 	 (interactive)
-	 (unless ,installed-version
-	   (message "Debug extension not installed, run M-x %s-setup to install it"
-		    ,dapfile))
-	 (if (string= ,version ,installed-version)
-	     (message "You are already up to date.")
-	   (message "Installing version %s" ,version)
-	   (message "Version %s installed." ,version))))))
+	 (if ,installed-version
+	     (if (string= ,version ,installed-version)
+		 (message "You are already up to date.")
+	       (message "Installing version %s" ,version)
+	       (dap-utils-get-vscode-extension ,publisher ,name ,version ,dest)
+	       (message "Version %s installed." ,version))
+	   (message "Debug extension not installed, run M-x %s-setup to install V%s"
+		    ,dapfile ,version))))))
 
 (provide 'dap-utils)
 ;;; dap-utils.el ends here

--- a/dap-utils.el
+++ b/dap-utils.el
@@ -155,12 +155,10 @@ PATH is the location of directory that contains the debugger. It shoul end with 
        (defun ,(intern (format "%s-update" dapfile)) ()
 	 ,help-string
 	 (interactive)
-	 (setq installed-version (if ,path
-				     (f-filename ,path)
-				   (car (directory-files ,constructed-path
+	 (setq installed-version (car (directory-files ,constructed-path
 							   nil
 							   "[[:digit:]]"
-							   t))))
+							   t)))
 	 (if installed-version
 	     (if (string= ,version installed-version)
 		 (message "You are already up to date.")

--- a/dap-utils.el
+++ b/dap-utils.el
@@ -142,22 +142,27 @@ With prefix, FORCED to redownload the extension." extension-name)))
 PUBLISHER is the vscode extension publisher.
 NAME is the vscode extension name.
 VERSION is the version to update to
-PATH is the location of directory that contains the debugger"
+PATH is the location of directory that contains the debugger. It shoul end with the version number"
   (let* ((extension-name (concat publisher "." name))
-	 (dest (or path
-		   (f-join dap-utils-extension-path
+	 (constructed-path (f-join dap-utils-extension-path
 			   "vscode"
-			   extension-name)))
+			   extension-name))
+	 (dest (or path constructed-path))
 	 (help-string (format "Updating %s to version %s"
 			      name
-			      version))
-	 (installed-version (car (directory-files path nil "[[:digit:]]" t))))
+			      version)))
     `(progn
        (defun ,(intern (format "%s-update" dapfile)) ()
 	 ,help-string
 	 (interactive)
-	 (if ,installed-version
-	     (if (string= ,version ,installed-version)
+	 (setq installed-version (if ,path
+				     (f-filename ,path)
+				   (car (directory-files ,constructed-path
+							   nil
+							   "[[:digit:]]"
+							   t))))
+	 (if installed-version
+	     (if (string= ,version installed-version)
 		 (message "You are already up to date.")
 	       (message "Installing version %s" ,version)
 	       (dap-utils-get-vscode-extension ,publisher ,name ,version ,dest)

--- a/dap-utils.el
+++ b/dap-utils.el
@@ -160,7 +160,6 @@ PATH is the location of directory that contains the dir named after the version.
        (defun ,(intern (format "%s-update" dapfile)) ()
 	 ,help-string
 	 (interactive)
-	 (message "Installed version is %s" ,installed-version)
 	 (unless ,installed-version
 	   (message "Debug extension not installed, run M-x %s-setup to install it"
 		    ,dapfile))

--- a/dap-utils.el
+++ b/dap-utils.el
@@ -142,8 +142,7 @@ With prefix, FORCED to redownload the extension." extension-name)))
 PUBLISHER is the vscode extension publisher.
 NAME is the vscode extension name.
 VERSION is the version to update to
-PATH is the location of directory that contains the dir named after the version. ex: ~/.emacs.d/.extention/vscond/foo.bar/ and should never contains x.x.* in it
-"
+PATH is the location of directory that contains the dir named after the version. ex: ~/.emacs.d/.extention/vscond/foo.bar/ and should never contains the version number in it"
   (let* ((extension-name (concat publisher "." name))
 	 (dest (or path
 		   (f-join dap-utils-extension-path

--- a/dap-utils.el
+++ b/dap-utils.el
@@ -167,8 +167,11 @@ PATH is the location of directory that contains the debugger. It shoul end with 
 	       (message "Installing version %s" ,version)
 	       (dap-utils-get-vscode-extension ,publisher ,name ,version ,dest)
 	       (message "Version %s installed." ,version))
+	       (delete-directory (f-join ,constructed-path installed-version) t t)
+	       (message "Deleting version %s", installed-version)
 	   (message "Debug extension not installed, run M-x %s-setup to install V%s"
-		    ,dapfile ,version))))))
+		    ,dapfile
+		    ,version))))))
 
 (provide 'dap-utils)
 ;;; dap-utils.el ends here

--- a/dap-utils.el
+++ b/dap-utils.el
@@ -137,5 +137,37 @@ With prefix, FORCED to redownload the extension." extension-name)))
          (message "%s: %s debug extension are not set. You can download it with M-x %s-setup"
                   ,dapfile ,extension-name ,dapfile)))))
 
+(defmacro dap-utils-vscode-update-function (dapfile publisher name version &optional path callback)
+  "Helper to create DAPFILE update function for vscode debug extension.
+PUBLISHER is the vscode extension publisher.
+NAME is the vscode extension name.
+VERSION is the version to update to
+PATH is the location of directory that contains the dir named after the version. ex: ~/.emacs.d/.extention/vscond/foo.bar/ and should never contains x.x.* in it
+"
+  (let* ((extension-name (concat publisher "." name))
+	 (dest (or path
+		   (f-join dap-utils-extension-path
+			   "vscode"
+			   extension-name)))
+	 (help-string (format "Updating %s to version %s"
+			      name
+			      version))
+	 (installed-version (car (directory-files dest
+						  nil
+						  "[[:digit:]]"
+						  t))))
+    `(progn
+       (defun ,(intern (format "%s-update" dapfile)) ()
+	 ,help-string
+	 (interactive)
+	 (message "Installed version is %s" ,installed-version)
+	 (unless ,installed-version
+	   (message "Debug extension not installed, run M-x %s-setup to install it"
+		    ,dapfile))
+	 (if (string= ,version ,installed-version)
+	     (message "You are already up to date.")
+	   (message "Installing version %s" ,version)
+	   (message "Version %s installed." ,version))))))
+
 (provide 'dap-utils)
 ;;; dap-utils.el ends here


### PR DESCRIPTION
Hi,
I implemented this function to allow the dynamic generation of specific dap update functions for different mode.
It checks if there is a debugger installed and compares both versions (mentioned in lsp and installed) then downloads the lsp version if is different from the previous one. Of course it will remove the installed one.
This functionality is aimed to provide the compatible version of the debugger Not the latest.

I would be happy to get feed back from you.
