### PR TITLE
`dap-go': bump vscode-go version

### DIFF
--- a/dap-go.el
+++ b/dap-go.el
@@ -41,7 +41,8 @@
            (new (f-join dap-go-debug-path "extension/dist/debugAdapter.js")))
        (if (f-exists? old)
            (progn
-             (lsp--warn "Go debug adapter is outdated; some features will not work properly")
+             (lsp--warn "Go debug adapter is outdated; some features will not work properly (map debugging).\n\
+Update `dap-go' using `C-u M-x dap-go-setup'")
              old)
          new)))
   "The path to the go debugger."

--- a/dap-go.el
+++ b/dap-go.el
@@ -35,8 +35,15 @@
   :group 'dap-go
   :type 'string)
 
-(defcustom dap-go-debug-program `("node"
-                                  ,(f-join dap-go-debug-path "extension/dist/debugAdapter.js"))
+(defcustom dap-go-debug-program
+  `("node"
+    ,(let ((old (f-join dap-go-debug-path "extension/out/src/debugAdapter/goDebug.js"))
+           (new (f-join dap-go-debug-path "extension/dist/debugAdapter.js")))
+       (if (f-exists? old)
+           (progn
+             (lsp--warn "Go debug adapter is outdated; some features will not work properly")
+             old)
+         new)))
   "The path to the go debugger."
   :group 'dap-go
   :type '(repeat string))

--- a/dap-go.el
+++ b/dap-go.el
@@ -36,7 +36,7 @@
   :type 'string)
 
 (defcustom dap-go-debug-program `("node"
-                                  ,(f-join dap-go-debug-path "extension/out/src/debugAdapter/goDebug.js"))
+                                  ,(f-join dap-go-debug-path "extension/dist/debugAdapter.js"))
   "The path to the go debugger."
   :group 'dap-go
   :type '(repeat string))
@@ -47,7 +47,7 @@
   :group 'dap-go
   :type 'string)
 
-(dap-utils-vscode-setup-function "dap-go" "golang" "go" dap-go-debug-path "0.15.0")
+(dap-utils-vscode-setup-function "dap-go" "golang" "go" dap-go-debug-path "0.22.1")
 
 (defun dap-go--populate-default-args (conf)
   "Populate CONF with the default arguments."


### PR DESCRIPTION
Version 0.15.0 of vscode-go does not handle maps correctly, adding nulls to
them. This bug is fixed in version 0.22.1, so bump it in `dap-go-setup`.

The layout of the extension changed: the executable that needs to be run is no
longer goDebug.js, bug dist/debugAdapter.js. As such, users will need to
manually update `dap-go` using `C-u dap-go-setup`.

Fixes #399.

@yyoncho as noted in the second paragraph, this is a breaking change. This is unavoidable though, as currently `dap-utils` doesn't version vscode-downloads. How should this be handled?