### PR TITLE
:compilation for `dap-debug`

### DIFF
--- a/dap-mode.el
+++ b/dap-mode.el
@@ -1686,7 +1686,8 @@ be used to compile the project, spin up docker, ...."
     (-if-let ((&plist :dap-compilation compilation) launch-args)
         (progn
           (cl-remf launch-args :dap-compilation)
-          (with-current-buffer (compilation-start compilation)
+          (with-current-buffer (compilation-start compilation t (lambda (&rest _)
+                                                                  "*DAP compilation*"))
             (let (window)
               (add-hook 'compilation-finish-functions
                         (lambda (buf status &rest _)

--- a/dap-mode.el
+++ b/dap-mode.el
@@ -1689,7 +1689,8 @@ after selecting configuration template."
                           (if (string= "finished\n" status)
                               (progn
                                 (when (and (not dap-debug-compilation-keep)
-                                           (window-live-p window))
+                                           (window-live-p window)
+                                           (eq buf (window-buffer window)))
                                   (delete-window window))
                                 (funcall cb))
                             (lsp--error "Compilation step failed"))))

--- a/dap-mode.el
+++ b/dap-mode.el
@@ -1646,7 +1646,7 @@ before starting the debug process."
         (run-hook-with-args 'dap-session-created-hook debug-session)))))
 
 (defcustom dap-debug-compilation-keep nil
-  "Whether `dap-debug' should keep the compile window on sucess.
+  "Whether `dap-debug' should keep the compile window on success.
 By default, it is hidden."
   :type 'boolean
   :group 'dap-mode)
@@ -1656,7 +1656,11 @@ By default, it is hidden."
   "Run debug configuration DEBUG-ARGS.
 
 If DEBUG-ARGS is not specified the configuration is generated
-after selecting configuration template."
+after selecting configuration template.
+
+:dap-compilation specifies a shell command to be run using
+`compilation-start' before starting the debug session. It could
+be used to compile the project, spin up docker, ...."
   (interactive (list (-> (dap--completing-read "Select configuration template: "
                                                (-mapcat #'funcall dap-launch-configuration-providers)
                                                'cl-first nil t)

--- a/dap-mode.el
+++ b/dap-mode.el
@@ -1679,9 +1679,9 @@ after selecting configuration template."
                (if (functionp launch-args)
                    (funcall launch-args #'dap-start-debugging-noexpand)
                  (dap-start-debugging-noexpand launch-args)))))
-    (-if-let ((&plist :compilation) launch-args)
+    (-if-let ((&plist :dap-compilation compilation) launch-args)
         (progn
-          (cl-remf launch-args :compilation)
+          (cl-remf launch-args :dap-compilation)
           (with-current-buffer (compilation-start compilation)
             (let (window)
               (add-hook 'compilation-finish-functions

--- a/docs/page/features.md
+++ b/docs/page/features.md
@@ -105,3 +105,15 @@ DAP are just like in VSCode and even support variables. See:
 
 - [launch.json](https://code.visualstudio.com/docs/editor/debugging)
 - [launch.json variables](https://code.visualstudio.com/docs/editor/variables-reference)
+
+## Compiling the project before debugging
+
+Many modern IDEs, for example Eclipse and VSCode (`preLaunchTask`), provide
+functionality to compile the project before starting the debug session.
+
+`dap-mode` also has such a feature: the `:dap-compilation` property of launch
+configurations ("dap-compilation" in `launch.json`) specifies a shell command
+that needs to execute successfully before the debug session is started.
+
+In the future, we want to support VSCode's `preLaunchTask` instead, but
+currently there is no tasks.json-compatible task runner for Emacs.


### PR DESCRIPTION
`dap-debug` now respects a `:compilation` option, which is a pre-compile step as
a `compilation` shell command (as discussed on discord with @yyoncho). This is
more of a POC and probably needs more refinement:

- [x] There is a "debug session exited" message printed for reason some (I was using "compilation", not "dap-compilation")
- [x] Documentation
- [ ] (out of scope?) task runner integration

----

#