### PR TITLE
Attach to remote Python (debugpy) adapter

### DIFF
--- a/dap-launch.el
+++ b/dap-launch.el
@@ -59,7 +59,7 @@ Yields nil if it cannot be found or there is no project."
   "Parse the project's launch.json as json data and return the result."
   (when-let ((launch-json (dap-launch-find-launch-json))
              (json-object-type 'plist)
-             ;; Try 'vector instead of 'list. With 'list for array type,
+             ;; Use 'vector instead of 'list. With 'list for array type,
              ;; json-encode-list interpreted a list with one plist element as
              ;; an alist. Using 'list, it turned the following value of
              ;; pathMappings:

--- a/dap-launch.el
+++ b/dap-launch.el
@@ -59,7 +59,32 @@ Yields nil if it cannot be found or there is no project."
   "Parse the project's launch.json as json data and return the result."
   (when-let ((launch-json (dap-launch-find-launch-json))
              (json-object-type 'plist)
-             (json-array-type 'list))
+             ;; Try 'vector instead of 'list. With 'list for array type,
+             ;; json-encode-list interpreted a list with one plist element as
+             ;; an alist. Using 'list, it turned the following value of
+             ;; pathMappings:
+             ;;
+             ;;     "pathMappings": [
+             ;;         {
+             ;;             "localRoot": "${workspaceFolder}",
+             ;;             "remoteRoot": "."
+             ;;         }
+             ;;     ]
+             ;;
+             ;; into:
+             ;;
+             ;;     ((:localRoot "${workspaceFolder}" :remoteRoot "."))
+             ;;
+             ;; and then into:
+             ;;
+             ;;     "pathMappings": {
+             ;;         "localRoot": [
+             ;;             "${workspaceFolder}",
+             ;;             "remoteRoot",
+             ;;             "."
+             ;;         ]
+             ;;     }
+             (json-array-type 'vector))
     (with-temp-buffer
       ;; NOTE: insert-file-contents does not move point
       (insert-file-contents launch-json)

--- a/dap-python.el
+++ b/dap-python.el
@@ -233,8 +233,18 @@ strings, for the sake of launch.json feature parity."
        (unless (plist-get conf :cwd)
          (cl-remf conf :cwd))
 
-       (plist-put conf :dap-server-path
-                  (list python-executable "-m" "debugpy.adapter")))
+       (pcase (plist-get conf :request)
+         ("launch"
+          (plist-put conf :dap-server-path
+                     (list python-executable "-m" "debugpy.adapter")))
+         ("attach"
+          (let* ((connect (plist-get conf :connect))
+                 (host (or (plist-get connect :host) "localhost"))
+                 (port (or (plist-get connect :port) 5678)))
+            (plist-put conf :host host)
+            (plist-put conf :debugServer port)
+            (cl-remf conf :connect)))))
+
       (_ (error "`dap-python': unknown :debugger type %S" debugger)))
     conf))
 


### PR DESCRIPTION
- Set :host and :debugServer instead of :dap-server-path for attach requests.
- Read launch config using 'vector for json-array-type to preserve structure of
  pathMappings across json-encode for the subsequent attach command.