### PR TITLE
dap-go: fix type error when splitting :args field

### DIFF
--- a/dap-go.el
+++ b/dap-go.el
@@ -64,7 +64,7 @@
 	       ))
 
 
-  (if (plist-get conf :args) (plist-put conf :args (split-string (plist-get conf :args))) ())
+  (if (stringp (plist-get conf :args)) (plist-put conf :args (split-string (plist-get conf :args))) ())
   
   (-> conf
       (dap--put-if-absent :dap-server-path dap-go-debug-program)


### PR DESCRIPTION
If the :args field is already present in a given configuration, the
code tries to call `split-string` on that field, which is appropriate
to do once but will fail on subsequent calls, such as those
encountered when running `dap-debug-last`. Changing the conditional
here from a nil check to a `stringp` check worked for me.