### PR TITLE
dap-firefox: update path to adapter bundle

### DIFF
--- a/dap-firefox.el
+++ b/dap-firefox.el
@@ -38,7 +38,7 @@
 
 (defcustom dap-firefox-debug-program `("node"
                                        ,(f-join dap-firefox-debug-path
-                                                "extension/out/firefoxDebugAdapter.js"))
+                                                "extension/dist/adapter.bundle.js"))
   "The path to the firefox debugger."
   :group 'dap-firefox
   :type '(repeat string))


### PR DESCRIPTION
Updates the default path of the Firefox debugger to to work with recent versions of vscode-firefox-debug.