### PR TITLE
Add dap-up-stack-frame and dap-down-stack-frame

### DIFF
--- a/dap-hydra.el
+++ b/dap-hydra.el
@@ -38,9 +38,11 @@
 _n_: Next           _ss_: Session            _bb_: Toggle          _dd_: Debug                 _ee_: Eval
 _i_: Step in        _st_: Thread             _bd_: Delete          _dr_: Debug recent          _er_: Eval region
 _o_: Step out       _sf_: Stack frame        _ba_: Add             _dl_: Debug last            _es_: Eval thing at point
-_c_: Continue       _sl_: List locals        _bc_: Set condition   _de_: Edit debug template   _ea_: Add expression.
-_r_: Restart frame  _sb_: List breakpoints   _bh_: Set hit count
-_Q_: Disconnect     _sS_: List sessions      _bl_: Set log message
+_c_: Continue       _su_: Up stack frame     _bc_: Set condition   _de_: Edit debug template   _ea_: Add expression.
+_r_: Restart frame  _sd_: Down stack frame   _bh_: Set hit count
+_Q_: Disconnect     _sl_: List locals        _bl_: Set log message
+                  _sb_: List breakpoints
+                  _sS_: List sessions
 "
   ("n" dap-next)
   ("i" dap-step-in)
@@ -50,6 +52,8 @@ _Q_: Disconnect     _sS_: List sessions      _bl_: Set log message
   ("ss" dap-switch-session)
   ("st" dap-switch-thread)
   ("sf" dap-switch-stack-frame)
+  ("su" dap-up-stack-frame)
+  ("sd" dap-down-stack-frame)
   ("sl" dap-ui-locals)
   ("sb" dap-ui-breakpoints)
   ("sS" dap-ui-sessions)


### PR DESCRIPTION
This is to fix https://github.com/emacs-lsp/dap-mode/issues/54

1. I used `-if-let*` instead of a bunch of nested `-if-let`s.  I feel this made the code much easier to read, at the expense of better error messages.  I'm open to changing it if you think the better error messages are worth it.
2. I didn't add any tests.  I did briefly glance at the tests, but I didn't find one testing `dap--go-to-stack-frame` which I would have liked to copy.  Let me know if you have any pointers on how to write some good tests.
4. I have only tested this with `dap-lldb`.
3. I added it to the hydra under the "Switch" section rather than the "Stepping" section.  I kind of wanted to put it to "Stepping", so that it would be easier to invoke, but it seemed like it fit better for the switching (given that's where the generic stack frame switching is).

Please let me know your thoughts, and thank you so much for allowing me to finally debug inside Emacs on Mac OS!