### PR TITLE
 dap-cpptools-setup set file mode on mac mono

### DIFF
--- a/dap-cpptools.el
+++ b/dap-cpptools.el
@@ -71,7 +71,7 @@ With prefix, FORCED to redownload the extension."
       (when (f-exists? mono)
         (set-file-modes mono #o0700))
       (when (f-exists? mono-mac)
-        (set-file-modes mono #o0700))
+        (set-file-modes mono-mac #o0700))
       (when (f-exists? lldb-mi)
         (set-file-modes lldb-mi #o0700)))
 


### PR DESCRIPTION
It currently checks if mono-mac exists, then attempts to set file modes on the linux mono