### PR TITLE
fix for #510: server log buffer not keeping env. variables for reexecution

### DIFF
--- a/dap-mode.el
+++ b/dap-mode.el
@@ -1622,11 +1622,10 @@ before starting the debug process."
                    :startup-function :environment-variables :hostName host) launch-args)
           (session-name (dap--calculate-unique-name name (dap--get-sessions)))
           (default-directory (or cwd default-directory))
-          (process-environment (if environment-variables
-                                   (cl-copy-list process-environment)
-                                 process-environment))
+	  (compilation-environment (append (mapcar (-lambda ((env . value)) (concat env "=" value))
+						   environment-variables)
+					   compilation-environment))
           program-process)
-    (mapc (-lambda ((env . value)) (setenv env value t)) environment-variables)
     (plist-put launch-args :name session-name)
 
     (when program-to-start


### PR DESCRIPTION
Fixes #510 

Change `dap-start-debugging-noexpand` to use the `compilation-environment`
variable instead of using `setenv` and `process-environment` directly.

In contrast to `process-environment` the `compilation-environment`
variable is saved as buffer-local by `compilation-start` and thus
it's value is kept for reexecution by the `recompile` command.