### PR TITLE
dap-ui: Fixed issue where control icon background was unspecified

### DIFF
--- a/dap-ui.el
+++ b/dap-ui.el
@@ -151,6 +151,11 @@ number - expand N levels."
   "Face for enabled breakpoint icon in fringe."
   :group 'dap-ui)
 
+(defface dap-ui-controls-fringe
+  '((t :inherit fringe))
+  "Face used for the background of debugger icons in fringe."
+  :group 'dap-ui)
+
 (defcustom  dap-ui-default-fetch-count 30
   "Default number of variables to load in inspect variables view for
 array variables."
@@ -494,7 +499,7 @@ DEBUG-SESSION is the debug session triggering the event."
               'display `(image :type png
                                :file ,(f-join dap-ui--control-images-root-dir image)
                                :ascent center
-                               :background ,(face-attribute 'fringe :background nil t))
+                               :background ,(face-attribute 'dap-ui-controls-fringe :background nil 'default))
               'local-map (--doto (make-sparse-keymap)
                            (define-key it [mouse-1] command))
               'pointer 'hand


### PR DESCRIPTION
This resolves #462.

If a user starts `dap-debug`, dap-mode creates a set of icons used to do common debug actions (step, continue, etc). These icons are created using `propertize` to make the text that displays the images on a background.

The existing setting uses the background color from the `fringe` face to set the background of the icon. The return value for the `face-attribute` function is not guaranteed to be specified. When the `:background` is unspecified, the space is made for the icons but nothing is displayed.

This PR defines a face to control the background color used for the debug icons. It defaults to using the background color defined in the `fringe` face, but will inherit from the `default` face if the `:background` attribute is unspecified in `fringe`.