### PR TITLE
dap-ui: Display `instructionPointerReference` when available

### DIFF
--- a/dap-ui.el
+++ b/dap-ui.el
@@ -698,7 +698,7 @@ DEBUG-SESSION is the debug session triggering the event."
                             (funcall
                              callback
                              (-map
-                              (-lambda ((stack-frame &as &hash "name" "line" "source"))
+                              (-lambda ((stack-frame &as &hash "name" "line" "source" "instructionPointerReference"))
                                 (let* ((current-session (dap--cur-session))
                                        (icon (if (and
                                                   (equal session current-session)
@@ -731,6 +731,9 @@ DEBUG-SESSION is the debug session triggering the event."
                                                                                     (gethash "name"))))
                                                                  'dap-ui-sessions-thread-active-face
                                                                'dap-ui-sessions-thread-face))
+                                                      (if instructionPointerReference
+                                                          (propertize (format " [%s]" instructionPointerReference) 'face 'dap-ui-sessions-thread-face)
+                                                        "")
                                                       (propertize (format " (%s:%s)" (or (gethash "name" source)
                                                                                          (gethash "path" source))
                                                                           line)


### PR DESCRIPTION
When provided by the debug adapter server, add the instruction pointer of each frame alongside its name in the `*dap-ui-sessions*` buffer.

For instance, the [SWI-Prolog debug adapter](https://github.com/eshelyaron/debug_adapter) reports for each frame exactly in which instruction pointer or stage the frame is stopped.

Here's an example of how the sessions tree looks with this addition:
![Screen Shot 2021-10-03 at 11 44 05](https://user-images.githubusercontent.com/83165320/135746605-743a4f25-504d-486c-9690-20c83dc56e20.png)

