### PR TITLE
Fix dap--put-if-absent to allow unsetting keys

### DIFF
--- a/dap-mode.el
+++ b/dap-mode.el
@@ -377,7 +377,7 @@ has succeeded."
 
 (defmacro dap--put-if-absent (config key form)
   "Update KEY to FORM if KEY does not exist in plist CONFIG."
-  `(if (plist-member ,config ,key) ,config (plist-put ,config ,key ,form)))
+  `(let ((c ,config)) (if (plist-member c ,key) c (plist-put c ,key ,form))))
 
 (defun dap--completing-read (prompt collection transform-fn &optional predicate
                                     require-match initial-input


### PR DESCRIPTION
Currently `dap--put-if-absent` uses the truthiness of the value returned by `plist-get` to determine whether a key is present, which seems incorrect.  This PR changes it to use `plist-member` to test for key presence.

**Example:**

The `dap-elixir` provider sets `taskArgs` and `requireFiles` in the default debug template, which causes failures when trying to run a `task` of `phx.server` instead of `test`.  The current logic of `dap--put-if-absent` makes it impossible to override those keys to `nil` in your local template.  So instead, you have to concoct a truthy Emacs Lisp value that is a no-op at the `mix` level.

Expected working template:
```elisp
(dap-register-debug-template
 "Phoenix Server"
 (list :type "Elixir"
       :name "mix phx.server"
       :task "phx.server"
       :taskArgs nil
       :requireFiles nil))
```

Actual working template:
```elisp
(dap-register-debug-template
 "Phoenix Server"
 (list :type "Elixir"
       :name "mix phx.server"
       :task "phx.server"
       :taskArgs '(nil)
       :requireFiles '("fake")))
```