### PR TITLE
Update dap-swi-prolog-debug-program default value

### DIFF
--- a/dap-swi-prolog.el
+++ b/dap-swi-prolog.el
@@ -30,7 +30,7 @@
 (require 'dap-mode)
 
 (defcustom dap-swi-prolog-debug-program
-    `(,(locate-file "swipl_debug_adapter" exec-path))
+    '("swipl" "-g" "[library(debug_adapter/main)]" "-t" "halt")
   "The path to the SWI-Prolog debug adapter."
   :group 'dap-swi-prolog
   :type '(repeat string))


### PR DESCRIPTION
Change the default for `dap-swi-prolog-debug-program` to work with SWI-Prolog DAP server versions 0.2.8+