### PR TITLE
Feature/docker aware dap mode

### DIFF
--- a/README.org
+++ b/README.org
@@ -50,6 +50,10 @@
     patching it, registering a debug provider e.t.c). This function examines a configuration file or falls back to the default configuration
     (which can be patched using the ~.dir-locals~ approach, take a note that the default configuration doesn't provide any sane defaults for debugging)
     and then operates on the combination of the two. This mechanism is the same as in ~lsp-docker~.
+
+    Note: currently you cannot use this mode when using a network connection to connect to debuggers (this part is yet to be implemented).
+    Still want to talk to debuggers over network? In order to do so you have to look at the ~launch-args~ patching done by ~dap-docker--dockerize-start-file-args~, you have to somehow assign ~nil~ to ~dap-server-path~ before it is passed further into session creation.
+    
     If you want to stick to a configuration file, take a look at the example below:
     
     #+begin_src yaml

--- a/README.org
+++ b/README.org
@@ -61,14 +61,14 @@
           destination: "/your/local/path/inside/a/container" # used both by 'lsp-docker' and 'dap-docker'
       debug:
         type: docker # only docker is supported
-        subtype: image # use only image subtype for now, 'container' support is yet to be tested
-        name: <docker image that has the debugger in> # you can omit this field
+        subtype: image # or 'container'
+        name: <docker image or container that has the debugger in> # you can omit this field
         # in this case the 'lsp-docker' ('server' section) image name is used
         enabled: true # you can explicitly disable 'dap-docker' by using 'false'
         provider: <your default language debug provider, double quoted string>
         template: <your default language debug template, double quoted string>
         launch_command: <an explicit command if you want to override a default one provided by the debug provider>
-        # e.g. if you have installed a debug server in a different directory
+        # e.g. if you have installed a debug server in a different directory, not used with 'container' subtype debuggers
     #+end_src
 
 

--- a/README.org
+++ b/README.org
@@ -52,7 +52,8 @@
     and then operates on the combination of the two. This mechanism is the same as in ~lsp-docker~.
 
     Note: currently you cannot use this mode when using a network connection to connect to debuggers (this part is yet to be implemented).
-    Still want to talk to debuggers over network? In order to do so you have to look at the ~launch-args~ patching done by ~dap-docker--dockerize-start-file-args~, you have to somehow assign ~nil~ to ~dap-server-path~ before it is passed further into session creation.
+    Still want to talk to debuggers over network? In order to do so you have to look at the ~launch-args~ patching
+    done by ~dap-docker--dockerize-start-file-args~, you have to somehow assign ~nil~ to ~dap-server-path~ before it is passed further into session creation.
     
     If you want to stick to a configuration file, take a look at the example below:
     

--- a/dap-docker.el
+++ b/dap-docker.el
@@ -1,0 +1,250 @@
+;;; dap-docker.el --- Debug Adapter Protocol mode for docker-wrapped servers      -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2022  Andrei Mochalov
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;; Author: Andrei Mochalov <factyy@gmail.com>
+;; Keywords: languages, debug, docker
+;; URL: https://github.com/emacs-lsp/dap-mode
+;; Package-Requires: ((emacs "26.1") (dash "2.18.0") (lsp-mode "6.0") (f "0.20.0") (s "1.12.0") (ht "2.3") (lsp-docker "1.0.0"))
+;; Version: 0.2
+
+;;; Commentary:
+;; Debug Adapter Protocol client support for Emacs and docker-wrapped servers.
+
+;;; Code:
+
+(require 'dap-mode)
+(require 'lsp-mode)
+(require 'lsp-docker)
+(require 'f)
+(require 's)
+(require 'ht)
+
+(defvar dap-docker-supported-server-types-subtypes
+  (ht ('docker (list 'container 'image)))
+  "A list of all supported server types and subtypes, currently only docker is supported")
+
+(defun dap-docker--is-enabled? (config)
+  "Check whether debugging is enabled"
+  (-if-let* ((server-info (gethash 'debug config))
+             (server-enabled (gethash 'enabled server-info)))
+      't
+    nil))
+
+(defun dap-docker--get-debug-provider-name (config)
+  "Check whether debugging is enabled"
+  (-if-let* ((server-info (gethash 'debug config))
+               (server-enabled (dap-docker--is-enabled? config)))
+      (gethash 'provider server-info)
+    (user-error "Either debug is not enabled or the config is invalid!")))
+
+(defun dap-docker--get-debug-template-name (config)
+  "Check whether debugging is enabled"
+  (-if-let* ((server-info (gethash 'debug config))
+               (server-enabled (dap-docker--is-enabled? config)))
+      (gethash 'template server-info)
+    (user-error "Either debug is not enabled or the config is invalid!")))
+
+(defun dap-docker--get-server-type-subtype (config)
+  "Get the server type"
+  (-if-let* ((server-info (gethash 'debug config))
+             (server-type (gethash 'type server-info))
+             (server-subtype (gethash 'subtype server-info)))
+      (cons (if (stringp server-type)
+                (intern server-type)
+              server-type)
+            (if (stringp server-subtype)
+                (intern server-subtype)
+              server-subtype))
+    (lsp-docker-get-server-type-subtype config)))
+
+(defun dap-docker--get-server-container-name (config)
+  "Get the server container name"
+  (-if-let* ((server-info (gethash 'debug config))
+             (server-subtype (gethash 'subtype server-info)))
+      (if (equal server-subtype "container")
+          (gethash 'name server-info))
+    (user-error "No debug container names are specified, you cannot use single container both for a language server and a debugging server")))
+
+(defun dap-docker--get-server-image-name (config)
+  "Get the server image name"
+  (-if-let* ((server-info (gethash 'debug config))
+             (server-subtype (gethash 'subtype server-info)))
+      (if (equal server-subtype "image")
+          (gethash 'name server-info))
+    (lsp-docker-get-server-image-name config)))
+
+(defun dap-docker--get-server-id (config)
+  "Get the server id"
+  (let ((server-info (gethash 'debug config)))
+    (if (stringp (gethash 'server server-info))
+        (intern (gethash 'server server-info))
+      (gethash 'server server-info))))
+
+(defun dap-docker--get-path-mappings (config)
+  "Get the server path mappings"
+  (lsp-docker-get-path-mappings config))
+
+(defun dap-docker--get-launch-command (config)
+  "Get the server launch command"
+  (let ((server-info (gethash 'debug config)))
+    (gethash 'launch_command server-info)))
+
+(defun dap-docker--check-server-type-subtype (supported-server-types-subtypes server-type-subtype)
+  "Verify that the combination of server (type . subtype) is supported by the current implementation"
+  (if (not server-type-subtype)
+      (user-error "No server type and subtype specified!"))
+  (if (ht-find (lambda (type subtypes)
+                 (let ((server-type (car server-type-subtype))
+                       (server-subtype (cdr server-type-subtype)))
+                   (if (and (equal server-type type) (-contains? subtypes server-subtype))
+                       t)))
+               supported-server-types-subtypes)
+      server-type-subtype
+    (user-error "No compatible server type and subtype found!")))
+
+(defun dap-docker--check-path-mappings (path-mappings)
+  "Verify that specified path mappings are all inside the project directory"
+  (--all? (or (f-descendant-of? (f-canonical (car it)) (f-canonical (lsp-workspace-root)))
+              (f-same? (f-canonical (car it)) (f-canonical (lsp-workspace-root))))
+          path-mappings))
+
+(defun dap-docker--verify-path-mappings-against-container (path-mappings container-name)
+  "Verify that specified path mappings are all included in container's path mappings"
+  (--all? (let ((source (car it))
+                (destination (cdr it)))
+            (-any? (lambda (mapping)
+                     (and (f-same? source (car mapping))
+                          (equal destination (cdr mapping))))
+                   (dap-docker--get-path-mappings-from-container container-name)))
+          path-mappings))
+
+(defun dap-docker--get-path-mappings-from-container (container-name)
+  "Get path mappings from a container"
+  (-let ((
+          (inspection-command-program . inspection-command-arguments)
+          (--map-when
+           (equal it "'{{.Mounts}}'")
+           "'{{json .Mounts}}'"
+           (s-split " " (format "%s container inspect -f '{{.Mounts}}' %s" lsp-docker-command container-name)))))
+    (-let (((exit-code . raw-output) (with-temp-buffer
+                                  (cons
+                                   (apply #'call-process inspection-command-program nil (current-buffer) nil inspection-command-arguments)
+                                   (buffer-string)))))
+      (if (equal exit-code 0)
+          (let* ((output (s-chop-prefix "'" (s-chop-suffix "'" (s-chomp raw-output))))
+                 (raw-mappings (append (json-parse-string output) nil)) ; using append to convert a vector to a list
+                 (bind-mappings (--filter (and (equal (gethash "Type" it) "bind") (equal (gethash "RW" it) t)) raw-mappings)))
+            (--map (cons (f-canonical (gethash "Source" it)) (f-canonical (gethash "Destination" it))) bind-mappings))
+        (user-error "Cannot analyze the following container: %s, exit code: %d" container-name exit-code)))))
+
+(defconst dap-docker-image-start-string "docker run --rm &mappings& -i &name& &entrypoint&")
+(defconst dap-docker-container-start-string "docker start -i &name&")
+
+(defun dap-docker--prepare-image-start-path (image-name path-mappings entrypoint)
+  "Get a command (splitted by spaces in a list form) for launching a server in a docker image"
+  (let* ((command (copy-sequence dap-docker-image-start-string))
+         (mappings-list (--map (s-join " " (list "-v" (s-join ":" (list (car it) (cdr it))))) path-mappings))
+         (mappings (s-join " " mappings-list)))
+    (--> command
+         (s-replace "&name&" image-name it)
+         (s-replace "&mappings&" mappings it)
+         (s-replace "&entrypoint&" entrypoint it))))
+
+(defun dap-docker--prepare-container-start-path (container-name _ _)
+  "Get a command (splitted by spaces in a list form) for launching a server in a docker container"
+  (let ((command (copy-sequence dap-docker-container-start-string)))
+    (--> command
+         (s-replace "&name&" container-name it))))
+
+(defun dap-docker--get-dockerized-debug-provider-name (debug-provider-name project-root)
+  "Create a new debug provider name using the original one and the project root"
+  (s-join "-"
+          (list
+           (->> project-root
+                (s-replace-all '(("/" . "-") ("." . "")))
+                (s-chop-suffix "-")
+                (s-chop-prefix "-"))
+           (s-concat debug-provider-name "Docker"))))
+
+(defun dap-docker--dockerize-start-file-args (conf project-config project-root)
+  "Add container launching and path mapping wrappers to start arguments"
+  (let* ((original-provider-name (plist-get conf :type))
+         (original-launch-command (if (listp (plist-get conf :dap-server-path))
+                                      (s-join " " (plist-get conf :dap-server-path))
+                                    (plist-get conf :dap-server-path)))
+         (original-name (plist-get conf :name))
+         (launch-command (or (dap-docker--get-launch-command project-config) original-launch-command))
+         (path-mappings (dap-docker--get-path-mappings project-config))
+         (server-type (car (dap-docker--check-server-type-subtype dap-docker-supported-server-types-subtypes (dap-docker--get-server-type-subtype project-config))))
+         (server-subtype (cdr (dap-docker--check-server-type-subtype dap-docker-supported-server-types-subtypes (dap-docker--get-server-type-subtype project-config))))
+         (container-name (dap-docker--get-server-container-name project-config))
+         (image-name (dap-docker--get-server-image-name project-config)))
+    (cond ((equal server-subtype 'container)
+           (-> conf
+               (plist-put :dap-server-path (s-split " " (dap-docker--prepare-container-start-path container-name path-mappings launch-command)))
+               (plist-put :type (dap-docker--get-dockerized-debug-provider-name original-provider-name project-root))
+               (plist-put :name (s-concat original-name "DockerContainer"))
+               (plist-put :path-mappings path-mappings)
+               (plist-put :local-to-remote-path-fn (-partial #'dap--local-to-remote-path (dap-docker--get-path-mappings project-config)))
+               (plist-put :remote-to-local-path-fn (-partial #'dap--remote-to-local-path (dap-docker--get-path-mappings project-config)))))
+          ((equal server-subtype 'image)
+           (-> conf
+               (plist-put :dap-server-path (s-split " " (dap-docker--prepare-image-start-path container-name path-mappings launch-command)))
+               (plist-put :type (dap-docker--get-dockerized-debug-provider-name original-provider-name project-root))
+               (plist-put :name (s-concat original-name "DockerImage"))
+               (plist-put :path-mappings path-mappings)
+               (plist-put :local-to-remote-path-fn (-partial #'dap--local-to-remote-path (dap-docker--get-path-mappings project-config)))
+               (plist-put :remote-to-local-path-fn (-partial #'dap--remote-to-local-path (dap-docker--get-path-mappings project-config))))))))
+
+(defun dap-docker--dockerize-debug-provider (debug-provider-name project-config project-root)
+  "Make a particular debug provider docker-aware in a project folder"
+  (-if-let* ((original-debug-provider (gethash debug-provider-name dap--debug-providers)))
+      (dap-register-debug-provider (dap-docker--get-dockerized-debug-provider-name debug-provider-name project-root)
+               (lambda (conf)
+                 (-> conf
+                     (original-debug-provider)
+                     (-rpartial #'dap-docker--dockerize-start-file-args project-config project-root))))))
+
+(defun dap-docker--dockerize-debug-template (debug-template-name project-config project-root)
+  "Make a particular debug template docker-aware in a project folder"
+  (-if-let* ((original-debug-template (--first (let* ((key (-first-item it))
+                                                      (properties (-slice it 1))
+                                                      (name (plist-get properties :name))
+                                                      (type (plist-get properties :type)))
+                                                 (equal name debug-template-name))
+                                               dap-debug-template-configurations)))
+      (let* ((key (-first-item original-debug-template))
+             (properties (-slice original-debug-template 1))
+             (name (plist-get properties :name)))
+        (dap-register-debug-template
+         (s-concat key ": Dockerized")
+         (-> (copy-sequence properties)
+             (plist-put :type (dap-docker--get-dockerized-debug-provider-name (dap-docker--get-debug-provider-name project-config) project-root))
+             (plist-put :name (s-concat name "Dockerized")))))))
+
+(defun dap-docker-register ()
+  "Make the current project debugger docker-aware"
+  (interactive)
+  (let* ((config (lsp-docker-get-config-from-lsp))
+         (project-root (lsp-workspace-root))
+         (original-provider-name (dap-docker--get-debug-provider-name config))
+         (original-template-name (dap-docker--get-debug-template-name config)))
+    (dap-docker--dockerize-debug-provider original-provider-name config project-root)
+    (dap-docker--dockerize-debug-template original-template-name config project-root)))
+
+(provide 'dap-docker)
+;;; dap-docker.el ends here

--- a/dap-docker.el
+++ b/dap-docker.el
@@ -95,9 +95,9 @@
         (intern (gethash 'server server-info))
       (gethash 'server server-info))))
 
-(defun dap-docker--get-path-mappings (config)
+(defun dap-docker--get-path-mappings (config project-root)
   "Get the server path mappings"
-  (lsp-docker-get-path-mappings config))
+  (lsp-docker-get-path-mappings config project-root))
 
 (defun dap-docker--get-launch-command (config)
   "Get the server launch command"
@@ -188,7 +188,7 @@
                                     (plist-get conf :dap-server-path)))
          (original-name (plist-get conf :name))
          (launch-command (or (dap-docker--get-launch-command project-config) original-launch-command))
-         (path-mappings (dap-docker--get-path-mappings project-config))
+         (path-mappings (dap-docker--get-path-mappings project-config project-root))
          (server-type (car (dap-docker--check-server-type-subtype dap-docker-supported-server-types-subtypes (dap-docker--get-server-type-subtype project-config))))
          (server-subtype (cdr (dap-docker--check-server-type-subtype dap-docker-supported-server-types-subtypes (dap-docker--get-server-type-subtype project-config))))
          (container-name (dap-docker--get-server-container-name project-config))

--- a/dap-docker.el
+++ b/dap-docker.el
@@ -135,8 +135,7 @@
 
 (defun dap-docker--get-path-mappings-from-container (container-name)
   "Get path mappings from a container"
-  (-let ((
-          (inspection-command-program . inspection-command-arguments)
+  (-let (((inspection-command-program . inspection-command-arguments)
           (--map-when
            (equal it "'{{.Mounts}}'")
            "'{{json .Mounts}}'"

--- a/dap-docker.el
+++ b/dap-docker.el
@@ -32,6 +32,7 @@
 (require 'f)
 (require 's)
 (require 'ht)
+(require 'dash)
 
 (defvar dap-docker-supported-server-types-subtypes
   (ht ('docker (list 'container 'image)))

--- a/dap-docker.el
+++ b/dap-docker.el
@@ -41,12 +41,9 @@
 
 (defun dap-docker--is-enabled? (config)
   "Check whether debugging is enabled"
-  (-if-let* ((server-info (gethash 'debug config))
-             (server-enabled (gethash 'enabled server-info)))
-      (if (equal server-enabled :false)
-          nil
-        't)
-    nil))
+  (-when-let* ((server-info (gethash 'debug config))
+               (server-enabled (gethash 'enabled server-info)))
+      (not (equal server-enabled :false))))
 
 (defun dap-docker--get-debug-provider-name (config)
   "Get the debug provider name also checking whether debugging is enabled"

--- a/dap-mode.el
+++ b/dap-mode.el
@@ -377,7 +377,7 @@ has succeeded."
 
 (defmacro dap--put-if-absent (config key form)
   "Update KEY to FORM if KEY does not exist in plist CONFIG."
-  `(let ((c ,config)) (if (plist-member c ,key) c (plist-put c ,key ,form))))
+  `(plist-put ,config ,key (or (plist-get ,config ,key) ,form)))
 
 (defun dap--completing-read (prompt collection transform-fn &optional predicate
                                     require-match initial-input

--- a/dap-mode.el
+++ b/dap-mode.el
@@ -377,7 +377,7 @@ has succeeded."
 
 (defmacro dap--put-if-absent (config key form)
   "Update KEY to FORM if KEY does not exist in plist CONFIG."
-  `(plist-put ,config ,key (or (plist-get ,config ,key) ,form)))
+  `(let ((c ,config)) (if (plist-member c ,key) c (plist-put c ,key ,form))))
 
 (defun dap--completing-read (prompt collection transform-fn &optional predicate
                                     require-match initial-input

--- a/dap-mode.el
+++ b/dap-mode.el
@@ -491,7 +491,6 @@ FILE-NAME is the filename in which the breakpoints have been udpated."
 
     ;; Update all of the active sessions with the list of breakpoints.
     (mapc (lambda (session)
-            (debug)
             (let ((set-breakpoints-req (dap--set-breakpoints-request
                                         session
                                         file-name

--- a/dap-ui.el
+++ b/dap-ui.el
@@ -286,7 +286,7 @@ DEBUG-SESSION is the debug session triggering the event."
   (when debug-session
     (-if-let* (((stack-frame &as &hash "source" "line" "column")
                 (dap--debug-session-active-frame debug-session))
-               (path (dap--get-path-for-frame stack-frame))
+               (path (dap--get-path-for-frame debug-session stack-frame))
                (buffer (find-buffer-visiting path)))
         (with-current-buffer buffer
           (goto-char (point-min))


### PR DESCRIPTION
Add support for docker-embedded debuggers (both in containers and images).
Mainly consists of an additional paths translation layer (look into `dap-mode.el` integration) and a config parsing / handling boilerplate code (mostly in `dap-docker.el`).

I don't know however if I have added all the dependencies to the right places (never worked on a complex elisp project before), so please take a closer look at this!

P.S: the approach I have taken is to "dockerize" the existing debug providers and templates (like in `lsp-docker`) so it is easier to understand the code if you are already familiar with that project. Also please take a look at the readme.