### PR TITLE
Added configuration for Unity debug adapter

### DIFF
--- a/dap-unity.el
+++ b/dap-unity.el
@@ -1,0 +1,67 @@
+;;; dap-unity.el --- Debug Adapter Protocol mode for Unity      -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2022  Owen Robertson
+
+;; Author: Owen Robertson
+;; Keywords: languages
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;; URL: https://github.com/yyoncho/dap-mode
+;; Package-Requires: ((emacs "25.1") (dash "2.14.1") (lsp-mode "4.0"))
+;; Version: 0.2
+
+;;; Commentary:
+;; Adapter for https://marketplace.visualstudio.com/items?itemName=Unity.unity-debug
+
+;;; Code:
+
+(require 'dap-mode)
+(require 'dap-utils)
+
+(defcustom dap-unity-debug-path (expand-file-name "vscode/Unity.unity-debug"
+                                                   dap-utils-extension-path)
+  "The path to unity-debug vscode extension."
+  :group 'dap-unity
+  :type 'string)
+
+(defcustom dap-unity-debug-program (expand-file-name "extension/bin/UnityDebug.exe"
+						     dap-unity-debug-path)
+  "The path to the unity debugger."
+  :group 'dap-unity
+  :type 'string)
+
+(dap-utils-vscode-setup-function "dap-unity" "Unity" "unity-debug"
+                                 dap-unity-debug-path
+				 nil
+				 (lambda () ;; After adapter is downloaded, flag the debugger as executable
+				   (unless (eq system-type 'windows-nt)
+				     (shell-command
+				      (concat "chmod u+x " dap-unity-debug-program)))))
+
+(defun dap-unity--populate-start-file-args (conf)
+  "Populate CONF with the required arguments."
+  (setq conf (-> conf
+                 (plist-put :type "unity")
+                 (plist-put :dap-server-path (list dap-unity-debug-program)))))
+
+(dap-register-debug-provider "unity" #'dap-unity--populate-start-file-args)
+
+(dap-register-debug-template "Unity Editor"
+                             (list :type "unity"
+                                   :request "launch"
+                                   :name "Unity Editor"))
+
+(provide 'dap-unity)
+;;; dap-unity.el ends here

--- a/docs/page/configuration.md
+++ b/docs/page/configuration.md
@@ -468,3 +468,28 @@ support you also need customize `dap-netcore-download-url`:
 
 Start debugging by selecting ".Net Core Launch (Console)" or ".Net
 Core Attach (Console)" from `dap-debug` menu.
+
+## Unity
+
+1.  Installation
+
+	- Automatic Installation:
+
+		- Add `dap-unity` to your configuration file
+
+		- Call `dap-unity-setup` to automatically download and extract the debugger
+
+		- If automatic installation fails, see the manual installation steps below
+
+	- Manual Installation:
+
+		- Download the unity-debug extension from the [VisualStudio Marketplace](https://marketplace.visualstudio.com/items?itemName=Unity.unity-debug)
+		
+		- Extract the extension contents (Default path: "{emacsconfigdir}/.extension/vscode/Unity.unity-debug/")
+		
+		- On non-Windows os, the debugger "{extensiondir}/extension/bin/UnityDebug.exe" must be flagged as executable
+			Using your favorite terminal: `chmod u+x UnityDebug.exe`
+		
+2.  Usage
+
+	Call `dap-debug` and select the "Unity Editor" template


### PR DESCRIPTION
Adding support for Unity (game engine) debug adapter.

Known Issues :
* Adapter will often fail to download from the vs marketplace requiring manual intervention.
* The adapter attempts to use DAP events that are not yet configured in dap-mode. This results in some "missing event" spam in the Messages buffer. The adapter is still very much usable, and the missing events can still be addressed in the future.