### PR TITLE
Add dap-debug-restart to dap-hydra

### DIFF
--- a/dap-hydra.el
+++ b/dap-hydra.el
@@ -39,7 +39,7 @@ _n_: Next           _ss_: Session            _bb_: Toggle          _dd_: Debug  
 _i_: Step in        _st_: Thread             _bd_: Delete          _dr_: Debug recent          _er_: Eval region
 _o_: Step out       _sf_: Stack frame        _ba_: Add             _dl_: Debug last            _es_: Eval thing at point
 _c_: Continue       _su_: Up stack frame     _bc_: Set condition   _de_: Edit debug template   _ea_: Add expression.
-_r_: Restart frame  _sd_: Down stack frame   _bh_: Set hit count
+_r_: Restart frame  _sd_: Down stack frame   _bh_: Set hit count   _ds_: Debug restart
 _Q_: Disconnect     _sl_: List locals        _bl_: Set log message
                   _sb_: List breakpoints
                   _sS_: List sessions
@@ -65,6 +65,7 @@ _Q_: Disconnect     _sl_: List locals        _bl_: Set log message
   ("bl" dap-breakpoint-log-message)
   ("dd" dap-debug)
   ("dr" dap-debug-recent)
+  ("ds" dap-debug-restart)
   ("dl" dap-debug-last)
   ("de" dap-debug-edit-template)
   ("ee" dap-eval)


### PR DESCRIPTION
This was discussed on Discord. The existing debug commands in `dap-hydra` do not kill the current debugging sessions, which leads to them piling up if the user isn't aware. In my case, it made emacs fill up my memory and crash.
The command that should be used if the user isn't interested in the old sessions is `dap-debug-restart`. This PR adds it to the hydra. `dr` was already taken, so I arbitrarily set it to `ds`. This can, of course, be changed. The same goes for the description. 
Maybe the description should contain some information that this is usually what you want if you're inside a debug session? I don't know how to express it succinctly though.