### PR TITLE
dap-swi-prolog: Add "Start Terminal" debug template

### DIFF
--- a/dap-swi-prolog.el
+++ b/dap-swi-prolog.el
@@ -42,7 +42,7 @@
                   (dap--put-if-absent :type "swi-prolog")
                   (dap--put-if-absent :cwd default-directory)
                   (dap--put-if-absent :module (buffer-file-name))
-                  (dap--put-if-absent :goal (read-string "Goal: " nil nil "true"))
+                  (dap--put-if-absent :goal (read-string "?- " nil nil "true"))
                   (dap--put-if-absent :name "SWI-Prolog Debug"))))
     conf))
 
@@ -52,6 +52,11 @@
                              (list :type "swi-prolog"
                                    :request "launch"
                                    :name "SWI-Prolog::Run"))
+(dap-register-debug-template "SWI-Prolog Start Terminal"
+                             (list :type "swi-prolog"
+                                   :goal "$run_in_terminal"
+                                   :request "launch"
+                                   :name "SWI-Prolog::Terminal"))
 
 (provide 'dap-swi-prolog)
 ;;; dap-swi-prolog.el ends here


### PR DESCRIPTION
[Version 0.4.0](https://github.com/eshelyaron/debug_adapter/releases/tag/v0.4.0) of the SWI-Prolog DAP server has support for the `runInTerminal` reverse request, which works quite well with `dap-mode` to pop a prolog REPL instrumented by the DAP server.

This PR adds a predefined debug template to `dap-swi-prolog` that triggers this mode of operation.

Here's an example screenshot :)
<img width="1792" alt="Screen Shot 2022-02-19 at 12 39 16" src="https://user-images.githubusercontent.com/83165320/154800663-b8af7590-04cd-4417-a19e-70071cee3a7b.png">

Cheers
