### PR TITLE
fix netcoredbg install without libxml2 support

### DIFF
--- a/docs/page/configuration.md
+++ b/docs/page/configuration.md
@@ -461,8 +461,7 @@ languages of Dotnet platform.
 (require 'dap-netcore)
 ```
 
-If you have Emacs 26 or older or if your Emacs built wilthout libxml2
-support you also need customize `dap-netcore-download-url`:
+If you have Emacs 26 or older you also need customize `dap-netcore-download-url`:
 
 `M-x` `customize` `RET` `dap-netcore-download-url` `RET`
 


### PR DESCRIPTION
- install netcoredbg without libxml2 support fixed
- upgrade without previous directory (or after upgrade error) fixed
- documentation updated