### PR TITLE
Change php-debug organization

### DIFF
--- a/dap-php.el
+++ b/dap-php.el
@@ -31,7 +31,7 @@
 (require 'dap-mode)
 (require 'dap-utils)
 
-(defcustom dap-php-debug-path (expand-file-name "vscode/felixfbecker.php-debug" dap-utils-extension-path)
+(defcustom dap-php-debug-path (expand-file-name "vscode/xdebug.php-debug" dap-utils-extension-path)
   "The path to php-debug vscode extension."
   :group 'dap-php
   :type 'string)
@@ -42,7 +42,7 @@
   :group 'dap-php
   :type '(repeat string))
 
-(dap-utils-vscode-setup-function "dap-php" "felixfbecker" "php-debug" dap-php-debug-path)
+(dap-utils-vscode-setup-function "dap-php" "xdebug" "php-debug" dap-php-debug-path)
 
 (defun dap-php--populate-start-file-args (conf)
   "Populate CONF with the required arguments."


### PR DESCRIPTION
The github organization for `vscode-php-debug` has changed as follows.
This pull request will make `dap-php-setup` work correctly.

https://github.com/felixfbecker/vscode-php-debug
↓
https://github.com/felixfbecker/vscode-php-debug
