### PR TITLE
support launch.json 'env' field

### DIFF
--- a/dap-launch.el
+++ b/dap-launch.el
@@ -106,6 +106,17 @@ Extract the name from the :name property."
 (defun dap-launch-parse-launch-json (json)
   "Return a list of all launch configurations in JSON.
 JSON must have been acquired with `dap-launch--get-launch-json'."
+
+  ;; map 'env' to 'environment-variables'
+  (mapc (lambda (conf)
+          (if-let ((env (plist-get conf :env))
+                   (json-object-type 'alist)
+                   (json-key-type 'string)
+                   (environment-variables (json-read-from-string (json-encode env))))
+              (plist-put conf :environment-variables environment-variables)
+            (dap--plist-delete conf :env)))
+        (plist-get json :configurations))
+
   (mapcar #'dap-launch-configuration-prepend-name
           (or (plist-get json :configurations) (list json))))
 


### PR DESCRIPTION
dap debug templates use `environment-variables` to set env variables.

ref: https://github.com/emacs-lsp/dap-mode/issues/202#issuecomment-578877223

`environment-variables` should be an alist with string keys but the
`env` field from launch.json is parsed as a plist with symbolic keys.

convert `env` to an alist with string keys and store the result inside
environment-variables