### PR TITLE
Prefer stack traces with a valid path

### DIFF
--- a/dap-mode.el
+++ b/dap-mode.el
@@ -832,7 +832,15 @@ will be reversed."
       ;; thread-id is the same as the active one
       (when (and (eq debug-session (dap--cur-session))
                  (eq thread-id (dap--debug-session-thread-id (dap--cur-session))))
-        (dap--go-to-stack-frame debug-session (cl-first stack-frames)))))
+        ;; filter stack frames excluding those associated to non-existing paths
+        ;; fall back to original stack-frames if none found
+        (-when-let (stack-frames
+                    (or (-filter (lambda(stack-frame)
+                                   (-when-let (path (dap--get-path-for-frame stack-frame))
+                                     (file-exists-p path)))
+                                 stack-frames)
+                        stack-frames))
+          (dap--go-to-stack-frame debug-session (cl-first stack-frames))))))
    debug-session))
 
 (defun dap--buffer-list ()


### PR DESCRIPTION
This is a proposal to filter stack traces in `dap--select-thread-id`.

Instead of jumping to the first stack trace in the list, filter them checking if `path` exists and jump to the first stack trace in the filtered list. Fall back to the original `stack-traces` if the filter produces an empty list.

This, I found, is especially useful for exceptions in eg: `lldb-vscode` where the first elements in  `stack-traces` have no valid `path`. This patch allows `dap` to at least open a buffer visiting the first valid `path` in the list and highlight the line that triggered the exception. 