### PR TITLE
Make number of stack frames to request when stopped configurable

### DIFF
--- a/dap-mode.el
+++ b/dap-mode.el
@@ -206,7 +206,7 @@ locations."
   :type 'hook
   :group 'dap-mode)
 
-(defcustom dap-stack-trace-limit 0
+(defcustom dap-stack-trace-limit 1000
   "Number of stack frames to return in the automatic stack trace
 request on hitting a breakpoint. 0 means to return all frames."
   :group 'dap-mode

--- a/dap-mode.el
+++ b/dap-mode.el
@@ -206,6 +206,12 @@ locations."
   :type 'hook
   :group 'dap-mode)
 
+(defcustom dap-stack-trace-limit 0
+  "Number of stack frames to return in the automatic stack trace
+request on hitting a breakpoint. 0 means to return all frames."
+  :group 'dap-mode
+  :type 'number)
+
 (defvar dap--debug-providers (make-hash-table :test 'equal))
 
 (defcustom dap-debug-template-configurations nil
@@ -822,7 +828,7 @@ will be reversed."
     (run-hook-with-args 'dap-stopped-hook debug-session))
 
   (dap--send-message
-   (dap--make-request "stackTrace" (list :threadId thread-id))
+   (dap--make-request "stackTrace" (list :threadId thread-id :levels dap-stack-trace-limit))
    (dap--resp-handler
     (-lambda ((&hash "body" (&hash "stackFrames" stack-frames)))
       (puthash thread-id


### PR DESCRIPTION
I often debug java projects with a stack depth of a couple of thousand frames. stepping is slow in this configuration, since the server gets asked for all of these frames on each step. making the number of requested frames configurable fixes that for me when I set it to a reasonable value. The stack trace in the session list is unaffected, so you can still access all the other frames.