### PR TITLE
python: make test-at-point work

### DIFF
--- a/dap-python.el
+++ b/dap-python.el
@@ -280,7 +280,7 @@ strings, for the sake of launch.json feature parity."
 
 (dap-register-debug-provider "python-test-at-point" 'dap-python--populate-test-at-point)
 (dap-register-debug-template "Python :: Run pytest (at point)"
-                             (list :type "python"
+                             (list :type "python-test-at-point"
                                    :args ""
                                    :program nil
                                    :module "pytest"


### PR DESCRIPTION
The debug-template for pytest (at point) now has the correct :type "python-test-at-point"
The corresponding debug-provider dap-python--populate-test-at-point is loaded