### PR TITLE
dap-go: upgrade extension version

### DIFF
--- a/dap-go.el
+++ b/dap-go.el
@@ -55,7 +55,7 @@ Update `dap-go' using `C-u M-x dap-go-setup'")
   :group 'dap-go
   :type 'string)
 
-(dap-utils-vscode-setup-function "dap-go" "golang" "go" dap-go-debug-path "0.22.1")
+(dap-utils-vscode-setup-function "dap-go" "golang" "go" dap-go-debug-path "0.32.0")
 
 (defun dap-go--populate-default-args (conf)
   "Populate CONF with the default arguments."


### PR DESCRIPTION
Hi, 

I try to download the extension with `dap-go-setup` but result in an empty folder. Update the extension version fixes this issue for me. Probably the old one is deleted for some reason.

I'm on Ubuntu 18, BTW.

Could you kindly take a look at the compatibility of this extension version?

Thank you!