### PR TITLE
Bare minimum Kotlin Debug Adapter setup

### DIFF
--- a/dap-kotlin.el
+++ b/dap-kotlin.el
@@ -1,3 +1,6 @@
+;; Commentary:
+;; Adapter for https://github.com/fwcd/kotlin-debug-adapter
+
 (require 'lsp-kotlin)
 (require 'dap-mode)
 

--- a/dap-kotlin.el
+++ b/dap-kotlin.el
@@ -19,6 +19,4 @@
 
 (dap-register-debug-provider "kotlin" #'dap-kotlin-populate-default-args)
 
-;;;###autoload(with-eval-after-load 'lsp-kotlin (require 'dap-kotlin))
-
 (provide 'dap-kotlin)

--- a/dap-kotlin.el
+++ b/dap-kotlin.el
@@ -1,0 +1,24 @@
+(require 'lsp-kotlin)
+(require 'dap-mode)
+
+(defun dap-kotlin-populate-launch-args (conf)
+  ;; we require mainClass and projectRoot to be filled in in the launch configuration.
+  ;; dap-kotlin does currently not support a fallback if not defined
+  (-> conf
+	  (dap--put-if-absent :request "launch")
+	  (dap--put-if-absent :name "Kotlin Launch")))
+
+(defun dap-kotlin-populate-default-args (conf)
+  (setq conf (pcase (plist-get conf :request)
+			   ("launch" (dap-kotlin-populate-launch-args conf))
+			   (_ (error "Unsupported dap-request. Only launch is currently supported"))))
+  
+  (-> conf
+	  (dap--put-if-absent :type "kotlin")
+	  (plist-put :dap-server-path (list lsp-kotlin-debug-adapter-path))))
+
+(dap-register-debug-provider "kotlin" #'dap-kotlin-populate-default-args)
+
+;;;###autoload(with-eval-after-load 'lsp-kotlin (require 'dap-kotlin))
+
+(provide 'dap-kotlin)


### PR DESCRIPTION
The absolute minimum configuration for using the [Kotlin Debug Adapter](https://github.com/fwcd/kotlin-debug-adapter) to debug Kotlin code. For some reason, [lsp-kotlin already has a variable for debug adapter path](https://github.com/emacs-lsp/lsp-mode/blob/master/clients/lsp-kotlin.el#L80), so reusing that one.

Currently only launch-requests are supported, which is a huge step forward from nothing. Future work may target attach requests as well, but I never use that, so would require some additional research from me to implement. 