### PR TITLE
Add link to python tutorial

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,7 @@ nav:
   - How to: page/how-to.md
   - Tutorials:
       - Clojure: page/clojure.md
+      - Python, debbuging with poetry + pyenv: page/python-poetry-pyenv.md
   - Gallery:
       - page/gallery.md
   - Adding a new debug server: page/adding-debug-server.md


### PR DESCRIPTION
Add missing link for https://github.com/emacs-lsp/dap-mode/pull/605
LSP-mode PR after this!