### PR TITLE
dap-cpptools: Update to v1.9.8

### DIFF
--- a/dap-cpptools.el
+++ b/dap-cpptools.el
@@ -32,13 +32,13 @@
   :group 'dap-cpptools
   :type 'string)
 
-(defcustom dap-cpptools-extension-version "0.29.0"
+(defcustom dap-cpptools-extension-version "1.9.8"
   "The version of the cpptools vscode extension."
   :group 'dap-cpptools
   :type 'string)
 
 (defcustom dap-cpptools-download-url
-  (format "https://github.com/microsoft/vscode-cpptools/releases/download/%s/cpptools-%s.vsix"
+  (format "https://github.com/microsoft/vscode-cpptools/releases/download/v%s/cpptools-%s.vsix"
           dap-cpptools-extension-version
           (alist-get system-type
                      '((windows-nt . "win32")
@@ -49,10 +49,8 @@
   :type 'string)
 
 (defcustom dap-cpptools-debug-program
-  `(,(concat dap-cpptools-debug-path
-             (if (eq system-type 'windows-nt)
-                 "/extension/debugAdapters/bin/OpenDebugAD7.exe"
-               "/extension/debugAdapters/OpenDebugAD7")))
+  `(,(concat dap-cpptools-debug-path "/extension/debugAdapters/bin/OpenDebugAD7"
+             (if (eq system-type 'windows-nt) ".exe" "")))
   "The path to the cpptools debug adapter."
   :group 'dap-cpptools
   :type '(repeat string))
@@ -64,16 +62,23 @@ With prefix, FORCED to redownload the extension."
   (unless (and (not forced) (file-exists-p dap-cpptools-debug-path))
     (dap-utils--get-extension dap-cpptools-download-url dap-cpptools-debug-path)
     (let* ((adapter-binary (cl-first dap-cpptools-debug-program))
-           (mono (f-join (f-parent adapter-binary) "mono.linux-x86_64"))
-           (mono-mac (f-join (f-parent adapter-binary) "mono.osx"))
-           (lldb-mi (f-join (f-parent adapter-binary) "lldb-mi/bin/lldb-mi")))
+           (adapters-path (f-parent (f-parent adapter-binary)))
+           (extension-bins-path (f-join (f-parent adapters-path) "bin"))
+           (bins
+            (append (mapcar #'(lambda (path) (f-join extension-bins-path path))
+                            '("cpptools" "cpptools-srv"))
+                    (mapcar #'(lambda (path) (f-join adapters-path path))
+                            '("bin/createdump" ;; In Linux and OSX versions
+                              ;; Exists in OSX version
+                              "lldb-mi/bin/lldb-mi"
+                              "lldb/bin/lldb-mi"
+                              "lldb/bin/debugserver"
+                              "lldb/bin/lldb-argdumper"
+                              "lldb/bin/lldb-launcher")))))
       (set-file-modes adapter-binary #o0700)
-      (when (f-exists? mono)
-        (set-file-modes mono #o0700))
-      (when (f-exists? mono-mac)
-        (set-file-modes mono-mac #o0700))
-      (when (f-exists? lldb-mi)
-        (set-file-modes lldb-mi #o0700)))
+      (dolist (bin bins)
+        (when (f-exists? bin)
+          (set-file-modes bin #o700))))
 
     (message "%s: Downloading done!" "dap-cpptools")))
 

--- a/dap-cpptools.el
+++ b/dap-cpptools.el
@@ -32,7 +32,13 @@
   :group 'dap-cpptools
   :type 'string)
 
-(defcustom dap-cpptools-extension-version "1.9.8"
+(defcustom dap-cpptools-extension-version
+  (let ((current-ver "1.9.8")
+        (installed-ver (dap-utils-vscode-get-installed-extension-version dap-cpptools-debug-path)))
+    (when (and installed-ver (version< installed-ver current-ver))
+      (warn "You have an old cpptools v%s. Please run `C-u 1 M-x dap-cpptools-setup' \
+to install the new v%s." installed-ver current-ver))
+    current-ver)
   "The version of the cpptools vscode extension."
   :group 'dap-cpptools
   :type 'string)

--- a/dap-cpptools.el
+++ b/dap-cpptools.el
@@ -71,9 +71,9 @@ With prefix, FORCED to redownload the extension."
            (adapters-path (f-parent (f-parent adapter-binary)))
            (extension-bins-path (f-join (f-parent adapters-path) "bin"))
            (bins
-            (append (mapcar #'(lambda (path) (f-join extension-bins-path path))
+            (append (mapcar (lambda (path) (f-join extension-bins-path path))
                             '("cpptools" "cpptools-srv"))
-                    (mapcar #'(lambda (path) (f-join adapters-path path))
+                    (mapcar (lambda (path) (f-join adapters-path path))
                             '("bin/createdump" ;; In Linux and OSX versions
                               ;; Exists in OSX version
                               "lldb-mi/bin/lldb-mi"

--- a/dap-utils.el
+++ b/dap-utils.el
@@ -85,6 +85,18 @@ PATH is the download destination path."
                    (f-join dap-utils-extension-path "github" (concat owner "." repo)))))
     (dap-utils--get-extension url dest)))
 
+(defun dap-utils-vscode-get-installed-extension-version (path)
+  "Check the version of the vscode extension installed in PATH.
+Returns nil if the extension is not installed."
+  (require 'xml)
+  (require 'dom)
+  (let* ((extension-manifest (f-join path "extension.vsixmanifest")))
+    (if (f-exists? extension-manifest)
+        (progn
+          (let ((pkg-identity (dom-by-tag (xml-parse-file extension-manifest) 'Identity)))
+            (dom-attr pkg-identity 'Version)))
+      nil)))
+
 (defmacro dap-utils-vscode-setup-function (dapfile publisher name &optional path version callback)
   "Helper to create DAPFILE setup function for vscode debug extension.
 PUBLISHER is the vscode extension publisher.

--- a/dap-utils.el
+++ b/dap-utils.el
@@ -91,11 +91,9 @@ Returns nil if the extension is not installed."
   (require 'xml)
   (require 'dom)
   (let* ((extension-manifest (f-join path "extension.vsixmanifest")))
-    (if (f-exists? extension-manifest)
-        (progn
-          (let ((pkg-identity (dom-by-tag (xml-parse-file extension-manifest) 'Identity)))
-            (dom-attr pkg-identity 'Version)))
-      nil)))
+    (when (f-exists? extension-manifest)
+      (let ((pkg-identity (dom-by-tag (xml-parse-file extension-manifest) 'Identity)))
+        (dom-attr pkg-identity 'Version)))))
 
 (defmacro dap-utils-vscode-setup-function (dapfile publisher name &optional path version callback)
   "Helper to create DAPFILE setup function for vscode debug extension.


### PR DESCRIPTION
- Update the default version for `cpptools` to the latest
- Fix the path of the `OpenDebugAD7` binary in new version, it has changed from `extension/debugAdapters/OpenDebugAD7` to`extension/debugAdapters/bin/OpenDebugAD7` 
- Make new binaries executable