### PR TITLE
dap-codelldb: Upgrade from v1.6.1 to v1.7.0

### DIFF
--- a/dap-codelldb.el
+++ b/dap-codelldb.el
@@ -22,8 +22,8 @@
 (require 'dap-utils)
 
 (defcustom dap-codelldb-extension-version "1.7.0"
-  "The version of the cpptools vscode extension."
-  :group 'dap-cpptools
+  "The version of the codelldb vscode extension."
+  :group 'dap-codelldb
   :type 'string)
 
 (defcustom dap-codelldb-download-url

--- a/dap-codelldb.el
+++ b/dap-codelldb.el
@@ -21,8 +21,14 @@
 (require 'dap-mode)
 (require 'dap-utils)
 
+(defcustom dap-codelldb-extension-version "1.7.0"
+  "The version of the cpptools vscode extension."
+  :group 'dap-cpptools
+  :type 'string)
+
 (defcustom dap-codelldb-download-url
-  (format "https://github.com/vadimcn/vscode-lldb/releases/download/v1.6.1/codelldb-x86_64-%s.vsix"
+  (format "https://github.com/vadimcn/vscode-lldb/releases/download/v%s/codelldb-x86_64-%s.vsix"
+          dap-codelldb-extension-version
           (alist-get system-type
                      '((windows-nt . "windows")
                        (darwin . "darwin")


### PR DESCRIPTION
- Add a custom variable `dap-codelldb-extension-version`
- Upgrade version from 1.6.1 to 1.7.0