### PR TITLE
Debug attach configuration for dap-kotlin

### DIFF
--- a/dap-kotlin.el
+++ b/dap-kotlin.el
@@ -11,15 +11,30 @@
 	  (dap--put-if-absent :request "launch")
 	  (dap--put-if-absent :name "Kotlin Launch")))
 
+(defun dap-kotlin-populate-attach-args (conf)
+  (-> conf
+      (dap--put-if-absent :request "attach")
+      (dap--put-if-absent :name "Kotlin Attach")
+      (dap--put-if-absent :projectRoot (lsp-workspace-root))
+      (dap--put-if-absent :hostName "localhost")
+      (dap--put-if-absent :port 5005)
+      (dap--put-if-absent :timeout 2000)))
+
 (defun dap-kotlin-populate-default-args (conf)
   (setq conf (pcase (plist-get conf :request)
-			   ("launch" (dap-kotlin-populate-launch-args conf))
-			   (_ (error "Unsupported dap-request. Only launch is currently supported"))))
+               ("launch" (dap-kotlin-populate-launch-args conf))
+               ("attach" (dap-kotlin-populate-attach-args conf))
+               (_ (error "Unsupported dap-request"))))
   
   (-> conf
 	  (dap--put-if-absent :type "kotlin")
 	  (plist-put :dap-server-path (list lsp-kotlin-debug-adapter-path))))
 
 (dap-register-debug-provider "kotlin" #'dap-kotlin-populate-default-args)
+
+(dap-register-debug-template "Kotlin Attach"
+                             (list :type "kotlin"
+                                   :request "attach"
+                                   :noDebug nil))
 
 (provide 'dap-kotlin)


### PR DESCRIPTION
Configuration for dap-kotlin for attaching to an already running debug process. Set some sane defaults as well, and made a template to be able to attach to an already running process with default settings (localhost at port 5005).