### PR TITLE
dap-dlv-go: fix an issue with test current function

### DIFF
--- a/dap-dlv-go.el
+++ b/dap-dlv-go.el
@@ -84,7 +84,7 @@
   (if (stringp (plist-get conf :args)) (plist-put conf :args (split-string (plist-get conf :args))) ())
 
   (when (string= (plist-get conf :name) "Test function")
-    (-when-let ((name (dap-dlv-go--extract-current--method-or-function-name t)))
+    (-when-let (name (dap-dlv-go--extract-current--method-or-function-name t))
       (dap--put-if-absent conf :args (list (format "-test.run=^%s$" name)))))
   
   (-> conf


### PR DESCRIPTION
Due to incorrect usage of `-when-let`, "Test function" was not working
as expected. Fix the usage of `-when-let` to correctly update `:args`.