### PR TITLE
test(makefile): add lint and checkdoc entries, remove unused variables

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,11 +26,11 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '16'
 
       - uses: emacs-eask/setup-eask@master
         with:
-          version: '0.4.29'
+          version: 'snapshot'
 
       - name: Run tests
         run: make ci

--- a/Makefile
+++ b/Makefile
@@ -3,21 +3,6 @@
 EMACS ?= emacs
 EASK ?= eask
 
-DAP-GENERAL := dap-launch.el dap-overlays.el dap-variables.el	\
-		dap-mode.el dapui.el dap-ui.el dap-mouse.el \
-		dap-hydra.el dap-utils.el
-
-# TODO: make a clients/ directory and update melpa recipe
-DAP-CLIENTS := dap-chrome.el dap-cpptools.el dap-edge.el		\
-		dap-elixir.el dap-firefox.el dap-gdb-lldb.el		\
-		dap-go.el dap-lldb.el dap-netcore.el dap-node.el	\
-		dap-php.el dap-pwsh.el dap-python.el dap-ruby.el	\
-		dap-codelldb.el dap-erlang.el dap-swi-prolog.el
-
-TEST-FILES := test/windows-bootstrap.el $(shell ls test/dap-*.el)
-LOAD-FILE = -l $(test-file)
-LOAD-TEST-FILES := $(foreach test-file, $(TEST-FILES), $(LOAD-FILE))
-
 ci: clean build compile test
 
 build:
@@ -36,3 +21,11 @@ test:
 	@echo "Testing..."
 	$(EASK) install-deps --dev
 	$(EASK) exec ert-runner -L .
+
+checkdoc:
+	@echo "Run checkdoc..."
+	$(EASK) lint checkdoc
+
+lint:
+	@echo "Run package-lint..."
+	$(EASK) lint package

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 EMACS ?= emacs
 EASK ?= eask
 
-ci: clean build compile test
+ci: clean build compile test checkdoc lint
 
 build:
 	$(EASK) package

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 EMACS ?= emacs
 EASK ?= eask
 
-ci: clean build compile test checkdoc lint
+ci: clean build compile test checkdoc
 
 build:
 	$(EASK) package


### PR DESCRIPTION
We aren't using `DAP-GENERAL`, `DAP-CLIENTS` ... variables, I guess we can remove it?

Add `lint` and `checkdoc`, but left unused for now.