### PR TITLE
Add M-x customize parameter to set the screen position for the controls toolbar

### DIFF
--- a/dap-ui.el
+++ b/dap-ui.el
@@ -54,6 +54,16 @@ number - expand N levels."
                  (number :tag "Expand level"))
   :group 'dap-ui)
 
+(defcustom dap-ui-controls-screen-position #'posframe-poshandler-frame-top-center
+  "On-screen position of controls when they are visible."
+  :type '(choice (const :tag "Top center" posframe-poshandler-frame-top-center)
+                 (const :tag "Top left" posframe-poshandler-frame-top-left-corner)
+                 (const :tag "Top right" posframe-poshandler-frame-top-right-corner)
+                 (const :tag "Bottom center" posframe-poshandler-frame-bottom-center)
+                 (const :tag "Bottom left" posframe-poshandler-frame-bottom-left-corner)
+                 (const :tag "Bottom right" posframe-poshandler-frame-bottom-right-corner))
+  :group 'dap-ui)
+
 (define-obsolete-variable-alias
   'dap-ui-expressiosn-expand-depth 'dap-ui-expressions-expand-depth
   "dap-mode 0.2.0"
@@ -573,7 +583,7 @@ DEBUG-SESSION is the debug session triggering the event."
               (select-frame (frame-parent pos-frame)))
             (posframe-show dap-ui--control-buffer
                            :string content
-                           :poshandler #'posframe-poshandler-frame-top-center
+                           :poshandler dap-ui-controls-screen-position
                            :internal-border-width 8))
         (posframe-hide dap-ui--control-buffer)))))
 

--- a/dap-ui.el
+++ b/dap-ui.el
@@ -493,7 +493,7 @@ DEBUG-SESSION is the debug session triggering the event."
       (setq-local lsp--cur-workspace workspace)
       (run-hooks 'dap-ui-breakpoints-ui-list-displayed-hook))))
 
-(defun dap-ui--brekapoints-list-cleanup ()
+(defun dap-ui--breakpoints-list-cleanup ()
   "Cleanup when buffer list has been deleted."
   (remove-hook 'dap-breakpoints-changed-hook 'dap-ui-refresh-breakpoints-list))
 
@@ -501,7 +501,7 @@ DEBUG-SESSION is the debug session triggering the event."
  'dap-ui-breakpoints-ui-list-mode-hook
  (lambda ()
    (add-hook 'dap-breakpoints-changed-hook 'dap-ui-refresh-breakpoints-list)
-   (add-hook 'kill-buffer-hook 'dap-ui--brekapoints-list-cleanup nil t)))
+   (add-hook 'kill-buffer-hook 'dap-ui--breakpoints-list-cleanup nil t)))
 
 ;;;###autoload
 (defun dap-ui-breakpoints-list ()


### PR DESCRIPTION
I found the default position of the dap-ui controls toolbar interfered with the top line of my preferred layout, so this PR turns the position of the controls toolbar into a customizable variable `dap-ui-controls-screen-position`. The variable accepts, as a value, the positioning functions used by `posframe`.

For example:

`(setq dap-ui-controls-screen-position #'posframe-poshandler-frame-top-left-corner)`

will position the controls toolbar in the top-left corner of the screen (my preference).

The default value remains `#'posframe-poshandler-frame-top-center` so current users will not be affected.