### PR TITLE
Feat: add cortex-debug

### DIFF
--- a/dap-cortex.el
+++ b/dap-cortex.el
@@ -1,0 +1,64 @@
+;;; dap-cortex.el --- Debug Adapter Protocol mode for cortex      -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2022 Mario Schlegel
+
+;; Author: Mario Schlegel m.schlegel@posteo.de
+;; Keywords: languages
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;; URL: https://github.com/mrsch/dap-mode
+;; Version: 0.1
+
+;;; Commentary:
+;; Adapter for https://github.com/Marus/cortex-debug
+
+;;; Code:
+
+(require 'dap-mode)
+(require 'dap-utils)
+
+(defcustom dap-cortex-path (expand-file-name "marus25.cortex-debug" dap-utils-extension-path)
+  "The path to the place at which the webfreak.debug extension."
+  :group 'dap-cortex
+  :type 'string)
+
+(defcustom dap-cortex-debug-program `("node" ,(f-join dap-cortex-path "dist/debugadapter.js"))
+  "The path to the cortex debugger."
+  :group 'dap-cortex
+  :type '(repeat string))
+
+(defun dap-cortex--populate-jlink (conf)
+  "Populate CONF with the required arguments."
+  (-> conf
+      (dap--put-if-absent :dap-server-path dap-cortex-debug-program)
+      (dap--put-if-absent :type "cortex-debug")
+      (dap--put-if-absent :name "Debug JLink")
+      (dap--put-if-absent :request "launch")
+      (dap--put-if-absent :gdbPath "arm-none-eabi-gdb")
+      (dap--put-if-absent :rttConfig '(:enabled :json-true :address "auto" :decoders [(:label "" :port 0 :type "console")]))
+      (dap--put-if-absent :gdbServerConsolePort 55878)
+      (dap--put-if-absent :cwd default-directory)
+      (dap--put-if-absent :extensionPath (concat dap-cortex-path "/"))
+      (dap--put-if-absent :preLaunchCommands [])
+      (dap--put-if-absent :postLaunchCommands [])
+      (dap--put-if-absent :interface "swd")
+      (dap--put-if-absent :swoConfig '(:enabled :json-false))
+      ))
+
+
+(dap-register-debug-provider "cortex-debug" 'dap-cortex--populate-jlink)
+
+(provide 'dap-cortex)
+;;; dap-cortex.el ends here

--- a/dap-mode.el
+++ b/dap-mode.el
@@ -626,10 +626,11 @@ thread exection but the server will log message."
     (while (not (string-empty-p chunk))
       (if (not (dap--parser-reading-body p))
           ;; Read headers
-          (let* ((body-sep-pos (string-match-p "\r\n\r\n" chunk)))
+          (let* ((body-sep-pos (string-match-p "\r\n\r\n" chunk))
+                 (header-pos (string-match-p "Content-Length" chunk)))
             (if body-sep-pos
                 ;; We've got all the headers, handle them all at once:
-                (let* ((header-raw (substring chunk 0 body-sep-pos))
+                (let* ((header-raw (substring chunk header-pos body-sep-pos))
                        (content (substring chunk (+ body-sep-pos 4)))
                        (headers
                         (mapcar 'dap--parse-header


### PR DESCRIPTION
Related to #224 

First try to get the cortex-debug extension running.
I had to make a change to `dap--parser-read` to skip some additional log outputs from cortex-debug. I don't know if this works with the other dap providers since I don't use any other.

I was able to successfully debug with the following config in `launch.json`:
```
{
      "name": "Debug nrf52832",
      "cwd": "${workspaceFolder}",
      "executable": "./build/firmware.elf",
      "request": "launch",
      "type": "cortex-debug",
      "device": "nRF52832_xxAA",
      "servertype": "jlink",
      "runToMain": true
    }
```