### PR TITLE
Python: Debug template for current file and root cwd

### DIFF
--- a/dap-python.el
+++ b/dap-python.el
@@ -269,6 +269,16 @@ strings, for the sake of launch.json feature parity."
                                    :request "launch"
                                    :name "Python :: Run file (buffer)"))
 
+(dap-register-debug-template
+  "Python :: Run file from project directory"
+  (list :type "python"
+        :args ""
+        :cwd (directory-file-name (nth 2 (project-current t)))
+        :module nil
+        :program nil
+        :request "launch"
+        :name "Run file from project directory"))
+
 (dap-register-debug-template "Python :: Run pytest (buffer)"
                              (list :type "python"
                                    :args ""


### PR DESCRIPTION
If using a python project structure, simply debugging the current file without setting cwd results in paths being different from regular execution.
For example:
myproject/src/main.py
myproject/src/lib.py.
If main.py imports lib.py as src.lib (as is common, if you run main from the root folder)
and the user debugs main.py while looking at the file, it will crash instantly if cwd is not set.
Therefore, this template is useful for debugging python projects.

Regarding the change in `dap-variables.el`:
The previous version of `(dap-variables--project-current-root)` crashed on my system,
and this fixes it. I guess it would also be possible to set it to `(lsp-workspace-root)`.