### PR TITLE
Debug template for current file and root cwd

### DIFF
--- a/dap-python.el
+++ b/dap-python.el
@@ -269,6 +269,14 @@ strings, for the sake of launch.json feature parity."
                                    :request "launch"
                                    :name "Python :: Run file (buffer)"))
 
+(dap-register-debug-template "Python :: Run file from project directory"
+                             (list :type "python"
+                                   :args ""
+                                   :cwd "${workspaceFolder}"
+                                   :module nil
+                                   :program nil
+                                   :request "launch"))
+
 (dap-register-debug-template "Python :: Run pytest (buffer)"
                              (list :type "python"
                                    :args ""


### PR DESCRIPTION
If using a python project structure, simply debugging the current file without setting cwd results in paths being different from regular execution.
For example:
myproject/src/main.py
myproject/src/lib.py.
If main.py imports lib.py as src.lib,
and the user debugs main.py while looking at the file, it will crash
instantly if cwd is not set.