### PR TITLE
Refactor debug provider names

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -2,6 +2,8 @@
 #+STARTUP: content
 
 * Changelog
+** 0.8
+   - [Breaking Change] Change debug provider names to match VS Code's naming: ~lldb~ to ~lldb-mi~ and ~codelldb~ to ~lldb~
 ** 0.7
    - [Breaking change] For ~dap-lldb.el~, change ~type~ to ~lldb-vscode~.
 ** 0.5

--- a/dap-codelldb.el
+++ b/dap-codelldb.el
@@ -60,7 +60,7 @@ With prefix, FORCED to redownload the extension."
     (message "%s: Downloading done!" "dap-codelldb")))
 
 (dap-register-debug-provider
- "codelldb"
+ "lldb"
  (lambda (conf)
    (let ((debug-port (dap--find-available-port)))
      (plist-put conf :program-to-start (format "%s --port %s" dap-codelldb-debug-program debug-port))

--- a/dap-gdb-lldb.el
+++ b/dap-gdb-lldb.el
@@ -130,9 +130,9 @@ With prefix, FORCED to redownload the extension."
       (dap--put-if-absent :valuesFormatting "prettyPrinters")))
       
 
-(dap-register-debug-provider "lldb" 'dap-gdb-lldb--populate-lldb)
+(dap-register-debug-provider "lldb-mi" 'dap-gdb-lldb--populate-lldb)
 (dap-register-debug-template "LLDB Run Configuration"
-                             (list :type "lldb"
+                             (list :type "lldb-mi"
                                    :request "launch"
                                    :name "LLDB::Run"
                                    :target nil


### PR DESCRIPTION
fixes #467
Note: Will break any existing `launch.json` files and configurations using `codelldb` or `lldb` as type names.