### PR TITLE
Fix #314. Give other tooltip-functions a chance to run.

### DIFF
--- a/dap-mouse.el
+++ b/dap-mouse.el
@@ -218,8 +218,7 @@ program is not executing.
 
 This function must return nil if it doesn't handle EVENT."
   (when (and (eventp event) dap-tooltip-mode)
-    (dap-tooltip-at-point (posn-point (event-end event))))
-  "")
+    (dap-tooltip-at-point (posn-point (event-end event)))))
 
 (provide 'dap-mouse)
 ;;; dap-mouse.el ends here


### PR DESCRIPTION
The documentation for `tooltip-functions` says

```
Each function is called with one argument EVENT which is a copy
of the last mouse movement event that occurred.  If one of these
functions displays the tooltip, it should return non-nil and the
rest are not called.
```

Since `dap-tooltip-tip` is prepended in a global variable `tooltip-functions`, and it always return an empty string, which is truthy value in elisp, therefore it preventing every other tooltip-functions a chance to be run.

This PR fixes that.