### PR TITLE
`cpptools+codelldb`: Updates, Better detection of the architecture

### DIFF
--- a/dap-codelldb.el
+++ b/dap-codelldb.el
@@ -27,12 +27,20 @@
   :type 'string)
 
 (defcustom dap-codelldb-download-url
-  (format "https://github.com/vadimcn/vscode-lldb/releases/download/v%s/codelldb-x86_64-%s.vsix"
+  (format "https://github.com/vadimcn/vscode-lldb/releases/download/v%s/codelldb-%s.vsix"
           dap-codelldb-extension-version
-          (alist-get system-type
-                     '((windows-nt . "windows")
-                       (darwin . "darwin")
-                       (gnu/linux . "linux"))))
+          (plist-get
+           (list 'windows-nt
+                 (cond ((string-match "\\(?:arm\\|aarch\\).?64" system-configuration) "aarch64-windows")
+                       (t "x86_64-windows"))
+                 'darwin
+                 (cond ((string-match "^aarch64.*" system-configuration) "aarch64-darwin")
+                       (t "x86_64-darwin"))
+                 'gnu/linux
+                 (cond ((string-match "^aarch64.*" system-configuration) "aarch64-linux")
+                       ((string-match "^arm.*" system-configuration) "arm-linux")
+                       (t "x86_64-linux")))
+           system-type))
   "The download url."
   :group 'dap-codelldb
   :type 'string)

--- a/dap-codelldb.el
+++ b/dap-codelldb.el
@@ -21,7 +21,7 @@
 (require 'dap-mode)
 (require 'dap-utils)
 
-(defcustom dap-codelldb-extension-version "1.7.0"
+(defcustom dap-codelldb-extension-version "1.7.4"
   "The version of the codelldb vscode extension."
   :group 'dap-codelldb
   :type 'string)

--- a/dap-cpptools.el
+++ b/dap-cpptools.el
@@ -33,7 +33,7 @@
   :type 'string)
 
 (defcustom dap-cpptools-extension-version
-  (let ((current-ver "1.9.8")
+  (let ((current-ver "1.11.5")
         (installed-ver (dap-utils-vscode-get-installed-extension-version dap-cpptools-debug-path)))
     (when (and installed-ver (version< installed-ver current-ver))
       (warn "You have an old cpptools v%s. Please run `C-u 1 M-x dap-cpptools-setup' \

--- a/dap-cpptools.el
+++ b/dap-cpptools.el
@@ -46,11 +46,18 @@ to install the new v%s." installed-ver current-ver))
 (defcustom dap-cpptools-download-url
   (format "https://github.com/microsoft/vscode-cpptools/releases/download/v%s/cpptools-%s.vsix"
           dap-cpptools-extension-version
-          (plist-get (list 'windows-nt "win32"
-                 'darwin (if (string-match "^aarch64.*" system-configuration)
-                             "osx-arm64"
-                             "osx")
-                 'gnu/linux "linux")
+          (plist-get
+           (list 'windows-nt
+                 (cond ((string-match "arm.?64" system-configuration) "win-arm64")
+                       ((string-match "64" system-configuration) "win64")
+                       (t "win32"))
+                 'darwin
+                 (cond ((string-match "^aarch64.*" system-configuration) "osx-arm64")
+                       (t "osx"))
+                 'gnu/linux
+                 (cond ((string-match "^aarch64.*" system-configuration) "linux-aarch64")
+                       ((string-match "^armhf.*" system-configuration) "linux-armhf")
+                       (t "linux")))
            system-type))
   "The download url."
   :group 'dap-cpptools

--- a/dap-cpptools.el
+++ b/dap-cpptools.el
@@ -48,7 +48,7 @@ to install the new v%s." installed-ver current-ver))
           dap-cpptools-extension-version
           (plist-get
            (list 'windows-nt
-                 (cond ((string-match "arm.?64" system-configuration) "win-arm64")
+                 (cond ((string-match "\\(?:arm\\|aarch\\).?64" system-configuration) "win-arm64")
                        ((string-match "64" system-configuration) "win64")
                        (t "win32"))
                  'darwin


### PR DESCRIPTION
## `dap-cpptools`
- Bump version v1.9.8 ➡️ v1.11.5
- Check for the architecture to download the right extension 

## `dap-codelldb`
- Bump version v1.7.0 ➡️ v1.7.4
- Check for the architecture to download the right extension 