### PR TITLE
dap-ui: save repl input history

### DIFF
--- a/dap-ui.el
+++ b/dap-ui.el
@@ -38,6 +38,7 @@
 (require 'gdb-mi)
 (require 'lsp-treemacs)
 (require 'posframe)
+(require 'f)
 
 (defvar posframe-mouse-banish)
 
@@ -1292,6 +1293,13 @@ request."
   :type 'string
   :group 'dap-ui)
 
+(defcustom dap-ui-repl-history-dir user-emacs-directory
+  "Directory path for DAP REPL input history files.
+Each dap `type' has its own input history file, e.g.
+~/.emacs.d/dap-ui-repl-python-history."
+  :type 'directory
+  :group 'dap-ui)
+
 (defvar dap-ui-repl-welcome
   (propertize "*** Welcome to Dap-Ui ***\n"
               'font-lock-face 'font-lock-comment-face)
@@ -1317,13 +1325,22 @@ buffer.")
   (with-no-warnings
     (setq-local company-backends '(dap-ui-repl-company)))
   (unless (comint-check-proc (current-buffer))
+    (setq comint-input-ring-file-name
+          (f-join dap-ui-repl-history-dir
+                  ;; concat unique history file for each dap type
+                  (concat
+                   "dap-ui-repl-"
+                   ;; :type is required so this should always exist
+                   (plist-get (dap--debug-session-launch-args (dap--cur-session)) :type)
+                   "-history")))
     (insert dap-ui-repl-welcome)
     (start-process "dap-ui-repl" (current-buffer) nil)
     (set-process-query-on-exit-flag (dap-ui-repl-process) nil)
     (goto-char (point-max))
     (set (make-local-variable 'comint-inhibit-carriage-motion) t)
     (comint-output-filter (dap-ui-repl-process) dap-ui-repl-prompt)
-    (set-process-filter (dap-ui-repl-process) 'comint-output-filter)))
+    (set-process-filter (dap-ui-repl-process) 'comint-output-filter)
+    (comint-read-input-ring 'silent)))
 
 (defun dap-ui-input-sender (_ input)
   "REPL comint handler.
@@ -1345,7 +1362,9 @@ INPUT is the current input."
                                              "\n"
                                              dap-ui-repl-prompt)))))
          debug-session)
-      (error "There is no stopped debug session"))))
+      (error "There is no stopped debug session")))
+  ;; save the input ring at the end so it doesn't interfere with anything
+  (comint-write-input-ring))
 
 ;;;###autoload
 (defun dap-ui-repl ()


### PR DESCRIPTION
This pull request enables repl input history to be saved across session on a per-type basis. For example, for `:type python`, the history is saved in a file called "dap-ui-repl-python-history".

The save path can be customized and defaults to `user-emacs-directory`.