### PR TITLE
Download node-debug2 from Open VSX registry

### DIFF
--- a/dap-node.el
+++ b/dap-node.el
@@ -39,8 +39,8 @@
   :group 'dap-node
   :type '(repeat string))
 
-(dap-utils-vscode-setup-function "dap-node" "ms-vscode" "node-debug2"
-                                 dap-node-debug-path)
+(dap-utils-openvsx-setup-function "dap-node" "ms-vscode" "node-debug2"
+                                  dap-node-debug-path)
 
 (defun dap-node--populate-start-file-args (conf)
   "Populate CONF with the required arguments."


### PR DESCRIPTION
Linked to: https://github.com/emacs-lsp/dap-mode/issues/554

Donwloading node-debug2 from VSCode Marketplace does not work. But the extension is available on Open VSX registry: https://open-vsx.org/extension/ms-vscode/node-debug2

This PR add support to download extensions from Open VSX registry and change `dap-node-setup` to use this feature.
Currently, direct download of the latest version of extension is not possible (https://github.com/eclipse/openvsx/issues/507). So it's down in 2 steps:
- query API (https://open-vsx.org/swagger-ui/index.html) to get metadata of extension and extract download URL
- download extension

PS: in addition to the technical difficulties related to VSCode Marketplace downloads, using Open VSX seems to be better from a legal point of view (according to https://www.eclipse.org/legal/open-vsx-registry-faq/).