### PR TITLE
Improve json-utils-sanitize-json

### DIFF
--- a/test/dap-test.el
+++ b/test/dap-test.el
@@ -172,6 +172,29 @@
 }"))
     (should (string= (dap-launch-test--sanitize-json orig) expected))))
 
+(ert-deftest dap-launch-test--delete-commas-before-comments ()
+  (let* ((orig "{
+    \"conf\": [
+        {
+          \"a\": \"b\",\t\v\u00A0
+        },
+        //{
+        //  \"b\": \"c\",\xD\u2028\u2029
+        //},\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006
+    ],\u2007\u2008\u2009\u200A\u202F\u205F\u3000
+}")
+         (expected "{
+    \"conf\": [
+        {
+          \"a\": \"b\"\t\v\u00A0
+        }
+        
+        
+        
+    ]\u2007\u2008\u2009\u200A\u202F\u205F\u3000
+}"))
+    (should (string= (dap-launch-test--sanitize-json orig) expected))))
+
 (ert-deftest dap-launch-test--comment-in-string ()
   (let ((orig "\"// orig\""))
     (should (string= orig (dap-launch-test--sanitize-json orig)))))


### PR DESCRIPTION
Trying to debug a project with this [launch.json](https://github.com/ansible/ansible-language-server/blob/main/.vscode/launch.json) failed with a "JSON Readtable error".

I investigated the error and found that `json-utils-sanitize-json` does not remove the trailing comma on line 20 because the regexp does not correctly handle the case where there is only comments between comma and "]".

Rather than trying to add this case to the regexp, this PR splits the regexp in two and changes `json-utils-sanitize-json`  to run in 2 passes:
- first, remove comments
- second, remove trailing commas

This should make `json-utils-sanitize-json` more robust against this kind of cases.