### PR TITLE
Feat/get latest GitHub release

### DIFF
--- a/dap-codelldb.el
+++ b/dap-codelldb.el
@@ -21,7 +21,7 @@
 (require 'dap-mode)
 (require 'dap-utils)
 
-(defcustom dap-codelldb-extension-version "1.7.4"
+(defcustom dap-codelldb-extension-version "1.8.1"
   "The version of the codelldb vscode extension."
   :group 'dap-codelldb
   :type 'string)

--- a/dap-cpptools.el
+++ b/dap-cpptools.el
@@ -33,7 +33,7 @@
   :type 'string)
 
 (defcustom dap-cpptools-extension-version
-  (let ((current-ver "1.11.5")
+  (let ((current-ver "1.13.8")
         (installed-ver (dap-utils-vscode-get-installed-extension-version dap-cpptools-debug-path)))
     (when (and installed-ver (version< installed-ver current-ver))
       (warn "You have an old cpptools v%s. Please run `C-u 1 M-x dap-cpptools-setup' \

--- a/dap-gdb-lldb.el
+++ b/dap-gdb-lldb.el
@@ -29,7 +29,7 @@
 (require 'dap-mode)
 (require 'dap-utils)
 
-(defcustom dap-gdb-lldb-extension-version "0.26.0"
+(defcustom dap-gdb-lldb-extension-version "0.26.1"
   "The version of the gdb-lldb vscode extension."
   :group 'dap-gdb-lldb
   :type 'string)

--- a/dap-utils.el
+++ b/dap-utils.el
@@ -102,13 +102,24 @@ PATH is the download destination dir."
                    (f-join dap-utils-extension-path "openvsx" (concat publisher "." name)))))
     (dap-utils--get-extension url dest)))
 
-(defun dap-utils-get-github-extension (owner repo version &optional path)
+(defun dap-utils-get-github-extension (owner repo &optional version path)
   "Get extension from github named OWNER/REPO with VERSION.
 PATH is the download destination path."
-  (let* ((url (format dap-utils-github-extension-url owner repo version))
+  (let* ((version (or version (dap-utils-get-github-extension-latest-version owner repo)))
+         (url (format dap-utils-github-extension-url owner repo version))
          (dest (or path
                    (f-join dap-utils-extension-path "github" (concat owner "." repo)))))
     (dap-utils--get-extension url dest)))
+
+(defun dap-utils-get-github-extension-latest-version (owner repo)
+  (let ((latest
+         (with-temp-buffer
+           (url-insert-file-contents
+            (format
+             "https://api.github.com/repos/%s/%s/releases/latest"
+             owner repo))
+           (json-parse-buffer :object-type 'plist))))
+    (car (last (split-string (plist-get latest :html_url) "/")))))
 
 (defun dap-utils-vscode-get-installed-extension-version (path)
   "Check the version of the vscode extension installed in PATH.


### PR DESCRIPTION
This PR adds a function to get the latest release from Github. The current `dap-utils-get-github-extension` requires an explicit version number, I've changed it to be optional (backward compatible), and when the `version` is set to nil, it gets the latest version.

TODO: Make use of the new feature to get the latest version of extensions.