### PR TITLE
Add sane default for projectRoot in Kotlin launch session

### DIFF
--- a/dap-kotlin.el
+++ b/dap-kotlin.el
@@ -5,11 +5,12 @@
 (require 'dap-mode)
 
 (defun dap-kotlin-populate-launch-args (conf)
-  ;; we require mainClass and projectRoot to be filled in in the launch configuration.
+  ;; we require mainClass to be filled in in the launch configuration.
   ;; dap-kotlin does currently not support a fallback if not defined
   (-> conf
-	  (dap--put-if-absent :request "launch")
-	  (dap--put-if-absent :name "Kotlin Launch")))
+      (dap--put-if-absent :request "launch")
+      (dap--put-if-absent :name "Kotlin Launch")
+      (dap--put-if-absent :projectRoot (lsp-workspace-root))))
 
 (defun dap-kotlin-populate-attach-args (conf)
   (-> conf


### PR DESCRIPTION
It seems like a default for `projectRoot` can be quite useful in launch-type sessions as well. This makes it easier to make general debug templates for running/debugging tests 🙂 

```emacs-lisp
(dap-register-debug-template "Kotlin run tests with launcher"
                             (list :type "kotlin"
                                   :request "launch"
                                   :mainClass "org.junit.platform.console.ConsoleLauncher --scan-class-path"
                                   :enableJsonLogging t
                                   :jsonLogFile "/Users/marie/jsonlog.txt"
                                   :noDebug nil))
```