### PR TITLE
Add Kotlin Debug Adapter logging arguments as variables

### DIFF
--- a/dap-kotlin.el
+++ b/dap-kotlin.el
@@ -4,13 +4,25 @@
 (require 'lsp-kotlin)
 (require 'dap-mode)
 
+(defcustom dap-kotlin-enable-log nil
+  "Turn on logging of debug adapter logs to file."
+  :type 'boolean
+  :group 'dap-kotlin)
+
+(defcustom dap-kotlin-log-path nil
+  "Path to the debug adapter log file."
+  :type 'string
+  :group 'dap-kotlin)
+
 (defun dap-kotlin-populate-launch-args (conf)
   ;; we require mainClass to be filled in in the launch configuration.
   ;; dap-kotlin does currently not support a fallback if not defined
   (-> conf
       (dap--put-if-absent :request "launch")
       (dap--put-if-absent :name "Kotlin Launch")
-      (dap--put-if-absent :projectRoot (lsp-workspace-root))))
+      (dap--put-if-absent :projectRoot (lsp-workspace-root))
+      (dap--put-if-absent :enableJsonLogging (lsp-json-bool dap-kotlin-enable-log))
+      (dap--put-if-absent :jsonLogFile dap-kotlin-log-path)))
 
 (defun dap-kotlin-populate-attach-args (conf)
   (-> conf
@@ -19,7 +31,9 @@
       (dap--put-if-absent :projectRoot (lsp-workspace-root))
       (dap--put-if-absent :hostName "localhost")
       (dap--put-if-absent :port 5005)
-      (dap--put-if-absent :timeout 2000)))
+      (dap--put-if-absent :timeout 2000)
+      (dap--put-if-absent :enableJsonLogging (lsp-json-bool dap-kotlin-enable-log))
+      (dap--put-if-absent :jsonLogFile dap-kotlin-log-path)))
 
 (defun dap-kotlin-populate-default-args (conf)
   (setq conf (pcase (plist-get conf :request)


### PR DESCRIPTION
After putting these in my own debug templates and similar for a while, I thought it would be great to be able to configure them using variables in dap-kotlin instead. This makes it possible to log the servers internal logs to a file. That is useful for debugging issues with the server/debug-adapter.