### PR TITLE
Change the :type of pytest-at-point debug template

### DIFF
--- a/dap-python.el
+++ b/dap-python.el
@@ -288,7 +288,7 @@ strings, for the sake of launch.json feature parity."
 
 (dap-register-debug-provider "python-test-at-point" 'dap-python--populate-test-at-point)
 (dap-register-debug-template "Python :: Run pytest (at point)"
-                             (list :type "python"
+                             (list :type "python-test-at-point"
                                    :args ""
                                    :program nil
                                    :module "pytest"


### PR DESCRIPTION
The `:type` of the debug template "Python :: Run pytest (at point)" should match the "LANGUAGE-ID" argument of the function `(dap-register-debug-provider)`, otherwise the "PROVIDE-CONFIGURATION-FN" is not called (and all tests in the current buffer are run, instead of just the test function at point).

I also humbly suggest to edit the doc string of `(dap-register-debug-provider)` so that it explicitly references the name of the property `:type` of the plist "CONFIGURATION-SETTINGS" in `(dap-register-debug-template)`. I'm not providing a MR for this because it's entirely possible that the problem is actually me not understanding what's going on here :slightly_smiling_face: 