### PR TITLE
Add support for OCaml through Earlybird

### DIFF
--- a/dap-ocaml.el
+++ b/dap-ocaml.el
@@ -1,0 +1,54 @@
+;;; dap-mode/dap-ocaml.el -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2018  Austin Theriault
+
+;; Author: Austin Theriault <austin@cutedogs.org>
+;; Keywords: languages
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;; URL: https://github.com/yyoncho/dap-mode
+;; Package-Requires: ((emacs "25.1") (dash "2.14.1") (lsp-mode "4.0"))
+;; Version: 0.2
+
+;;; Commentary:
+;; Adapter for OCaml Earlybird (https://github.com/hackwaly/ocamlearlybird)
+
+;;; Code:
+
+(require 'dap-mode)
+
+(defcustom dap-ocaml-executable "ocamlearlybird"
+  "Path to the OCaml Earlybird executable."
+  :group 'dap-ocaml
+  :risky t
+  :type 'file)
+
+(defun dap-ocaml--populate-start-file-args (conf)
+  "Populate CONF with the start file argument."
+  (-> conf
+      (dap--put-if-absent :console "internalConsole") ;; integratedTerminal doesn't work
+      (dap--put-if-absent :dap-server-path (list dap-ocaml-executable "debug"))))
+
+(dap-register-debug-provider "ocaml.earlybird" 'dap-ocaml--populate-start-file-args)
+(dap-register-debug-template "OCaml Debug Template"
+                             (list :type "ocaml.earlybird"
+                                   :request "launch"
+                                   :name "OCaml::Run"
+                                   :program nil
+                                   :arguments nil))
+
+
+(provide 'dap-ocaml)
+;;; dap-ocaml.el ends here

--- a/docs/page/configuration.md
+++ b/docs/page/configuration.md
@@ -656,3 +656,23 @@ Core Attach (Console)" from `dap-debug` menu.
 2.  Usage
 
 	Call `dap-debug` and select the "Unity Editor" template
+
+## OCaml
+
+[earlybird](https://github.com/hackwaly/ocamlearlybird) is an OCaml debugger with support for DAP.
+
+1. Installation
+
+   - Install earlybird through `opam install earlybird`
+   
+   - Put in your configuration file:
+
+   ``` elisp
+   (require 'dap-ocaml)
+   ```
+
+2. Usage
+
+    Call `dap-debug` and edit the "OCaml Debug Template". Make sure to set the program field as the path of your *byte-code* compiled program.
+    Note that this debugger _only_ works with bytecode compiled OCaml programs.
+  


### PR DESCRIPTION
This PR adds support for OCaml through the newly revived [earlybird](https://github.com/hackwaly/ocamlearlybird) debugger.