### PR TITLE
feat: improve breakpoint refresh efficiency by targeting only buffers…

### DIFF
--- a/dap-mode.el
+++ b/dap-mode.el
@@ -861,11 +861,7 @@ will be reversed."
 (defun dap--buffers-w-breakpoints ()
   "Get only the buffers featuring at least one breakpoint"
   ;; get the list from the keys of the breakpoint hash-table
-  (let ((buffers-w-bp ()))
-    (maphash
-     (lambda (k v) (push k buffers-w-bp))
-     (dap--get-breakpoints))
-    buffers-w-bp))
+  (ht-keys (dap--get-breakpoints)))
 
 (defun dap--refresh-breakpoints ()
   "Refresh breakpoints for DEBUG-SESSION."


### PR DESCRIPTION
Hello!

In my workflow I often use `persp` and `eyebrowse`, when reloading a saved layout the buffer count can quickly reach hundreds.

When debugging through DAP, I experience a very slow execution of the following operations:
- quitting a session
- deleting a session

Step debugging the issue I figure out that the time consuming function is `dap--refresh-breakpoints`. This is caused by the function cycling through ALL buffers visiting a file and checking for each of them whether they feature a breakpoint or notfd.

I improved the function by cycling only through the files known to have a breakpoint (i.e. the keys of the hash-table from `dap--get-breakpoints`).

This fix works like a charm for me, though let me know whether I have not considered corner cases that would break this approach.