### PR TITLE
dap-python: Support attach to an existing process

### DIFF
--- a/docs/page/configuration.md
+++ b/docs/page/configuration.md
@@ -182,6 +182,27 @@ These parameters are handled by templates of type `python`:
 
 Remaining parameters are forwarded to the respective debugger.
 
+4. Attach to an existing process
+  `dap-python` supports also the "attach" mode to attach and debug a long running script.
+    A template named "Python :: Attach to running process" is also pre-registered for this purpose.
+    ```elisp
+    (dap-register-debug-template "Python :: Attach to running process"
+      (list :type "python"
+            :request "attach"
+            :processId "${command:pickProcess}"
+            :name "Python :: Attach to running process"))
+    ```
+    The `${command:pickProcess}` configuration variable used by default to facilitate the user
+    selecting the debug process by a completion popping up window. The real `processId` can
+    always be specified using its *pid*.
+    **Note**: on Linux this is achieved using the [ptrace syscall](https://www.man7.org/linux/man-pages/man2/ptrace.2.html "ptrace syscall man page")
+    wrapped inside the GDB tool, which means that for distributions that enable YAMA (e.g. Ubuntu) some additional steps may be necessary:
+      - Install GDB.
+      - Turn on classic ptrace permission
+        ```bash
+        sudo sh -c 'echo 0 > /proc/sys/kernel/yama/ptrace_scope'
+        ```
+
 
 ## Ruby
 


### PR DESCRIPTION
This is modified version of https://github.com/emacs-lsp/dap-mode/pull/384

I've fixed previous PR, so it works with `debugpy` now.
Didn't check for ptwsd though.