### PR TITLE
Fix 404 error when attempting to download OpenVSX extensions

### DIFF
--- a/dap-utils.el
+++ b/dap-utils.el
@@ -61,7 +61,7 @@
   :type 'string)
 
 (defcustom dap-utils-openvsx-extension-api-url
-  "https://open-vsx.org/api/%s/%s/%s/"
+  "https://open-vsx.org/api/%s/%s/%s"
   "Open VSX extension api url."
   :group 'dap-utils
   :type 'string)


### PR DESCRIPTION
This change fixes this error when running `(dap-node-setup)`: `url-insert-file-contents: https://open-vsx.org/api/ms-vscode/node-debug2/latest/: Not found`

The problem was that the OpenVSX URL template string had a trailing slash, which is not handled by OpenVSX's Registry API Controller: https://github.com/eclipse/openvsx/blob/master/server/src/main/java/org/eclipse/openvsx/RegistryAPI.java#L348

I can't really find a blame in the OpenVSX repo which could've caused the extraneous trailing slash to stop working. Maybe the update to Java 17?

As you can see, there's no trailing slash at the end, so the route doesn't get mached in the controller and causes a 404 Not Found.

Just removing the slash does the job and `(dap-node-setup)` runs successfully.

References:
- https://github.com/emacs-lsp/dap-mode/issues/554#issuecomment-1712898562
- https://github.com/emacs-lsp/dap-mode/pull/700

You can also try it yourself:
- 404: https://open-vsx.org/api/ms-vscode/node-debug2/latest/
- Works: https://open-vsx.org/api/ms-vscode/node-debug2/latest (no trailing slash)