### PR TITLE
fix: get list of buffers (not files) with breakpoints

### DIFF
--- a/dap-mode.el
+++ b/dap-mode.el
@@ -861,8 +861,10 @@ will be reversed."
 
 (defun dap--buffers-w-breakpoints ()
   "Get only the buffers featuring at least one breakpoint"
-  ;; get the list from the keys of the breakpoint hash-table
-  (ht-keys (dap--get-breakpoints)))
+  ;; extract the list of buffers featuring a breakpoint from their first breakpoint marker
+  ;; (as stored in the LSP metadata)
+  (--map (marker-buffer (plist-get (car it) :marker))
+   (ht-values (dap--get-breakpoints))))
 
 (defun dap--refresh-breakpoints ()
   "Refresh breakpoints for DEBUG-SESSION."


### PR DESCRIPTION
This is a fix for a bug I erroneously introduces in PR #754 . 

The function `dap--buffers-w-breakpoints` was returning a list of files names instead of a list of buffers. This in turn broke the `dap--switch-to-session`.

With this fix, the list of buffers is inferred by the first marker of the first breakpoint found for each file.