### PR TITLE
Use :type python-test-at-point in "Run pytest (at point)"

### DIFF
--- a/dap-python.el
+++ b/dap-python.el
@@ -298,7 +298,7 @@ strings, for the sake of launch.json feature parity."
 
 (dap-register-debug-provider "python-test-at-point" 'dap-python--populate-test-at-point)
 (dap-register-debug-template "Python :: Run pytest (at point)"
-                             (list :type "python"
+                             (list :type "python-test-at-point"
                                    :args ""
                                    :program nil
                                    :module "pytest"


### PR DESCRIPTION
Hi there :wave: , 

I found that the template "Run pytest (at point)" was running the whole buffer instead of the test at point. I think the simple fix in the template should do the trick. 