### PR TITLE
Protect breakpoint persistence from print-* vars

### DIFF
--- a/dap-mode.el
+++ b/dap-mode.el
@@ -456,7 +456,11 @@ This is in contrast to merely setting it to 0."
     (make-directory (file-name-directory file) t)
     (with-temp-file file
       (erase-buffer)
-      (insert (prin1-to-string to-persist)))))
+      ;; Starting with Emacs 29, `prin1' takes an optional third argument
+      ;; which removes the need for these default bindings.
+      (let ((print-length nil)
+            (print-level nil))
+        (insert (prin1-to-string to-persist))))))
 
 (defun dap--set-sessions (debug-sessions)
   "Update list of debug sessions for WORKSPACE to DEBUG-SESSIONS."


### PR DESCRIPTION
### Summary

This PR comprises two commits:
1. the first fixes the pitfall described below, reported by @cpitclaudel;
2. the second looks at some opportunities for simplification spotted while looking around for places that do printing.

### Pitfall

The output of printing functions (including `prin1` and, by extension, `format` with a `%s` sequence) is affected by a set of [output variables](https://gnu.org/s/emacs/manual/html_node/elisp/Output-Variables.html) that both end-users and libraries can tweak.

This is fine in the more common use of these functions to format messages, but the problem is that the same functions are also the most convenient way to serialise/persist data.

Serialisation should be robust to non-default values of `print-length` and `print-level` in particular, as setting these to small numbers can lead to accidental data loss (and in some cases unreadable output).

For example, the following roundtrip returns `"(0 ...)"` instead of the expected `"(0 1 2 3)"`:

```el
(let (file)
  (unwind-protect
      (let ((data (number-sequence 0 3)))
        (setq file (make-temp-file "my-" nil ".eld"))
        (let ((print-length 1))
          (dap--persist file data))
        (with-temp-buffer
          (insert-file-contents file)
          (buffer-string)))
    (when file (delete-file file))))
```

Starting in Emacs 29, `prin1` and co. gained a new optional argument precisely to protect against this problem.  In the meantime, this PR ensures that `print-length` and `print-level` are set to their default values during serialisation.