### PR TITLE
Changed prioirty typo to priority

### DIFF
--- a/dap-ui.el
+++ b/dap-ui.el
@@ -64,7 +64,7 @@ number - expand N levels."
   :group 'dap-ui)
 
 (defcustom dap-ui-overlay-priority 100
-  "Overlay's base prioirty."
+  "Overlay's base priority."
   :type 'integer
   :group 'dap-ui)
 


### PR DESCRIPTION
While setting up dap mode in emacs, noticed that in dap-ui-overlay-priority description there was a typo. Fixed typo with this PR.