### PR TITLE
Fixing bad args handling in netcore test

### DIFF
--- a/dap-netcore.el
+++ b/dap-netcore.el
@@ -152,6 +152,14 @@ the function needs to examine, starting with FILE."
              (setq file nil))))
     (if root (file-name-as-directory root))))
 
+(defun dap-netcore--locate-project-dir ()
+  "Locate .NET project directory."
+  (f-full
+   (or
+    (dap-netcore--locate-dominating-file-wildcard
+     default-directory "*.*proj")
+    (lsp-workspace-root))))
+
 (defun dap-netcore--populate-args (conf)
   "Populate CONF with arguments to launch or attach netcoredbg."
   (dap--put-if-absent conf :dap-server-path (list (dap-netcore--debugger-locate-or-install) "--interpreter=vscode"))
@@ -160,11 +168,7 @@ the function needs to examine, starting with FILE."
      (dap--put-if-absent
       conf
       :program
-      (let ((project-dir (f-full
-                          (or
-                           (dap-netcore--locate-dominating-file-wildcard
-                            default-directory "*.*proj")
-                           (lsp-workspace-root)))))
+      (let ((project-dir (dap-netcore--locate-project-dir)))
         (save-mark-and-excursion
           (find-file (concat (f-slash project-dir) "*.*proj") t)
           (let ((res (if (libxml-available-p)


### PR DESCRIPTION
Hello, this fixes a bug on `dap-netcore-debug-test` regarding arguments handling.
For some reason, using --filter or any, ended up not finding the directory or duplicating because of `start-process` behaviour.
now, args and directory are passed to the dotnet process properly to not interfere while using them.