### PR TITLE
Fix error in `dap--buffers-w-breakpoints` when a debug session ends

### DIFF
--- a/dap-mode.el
+++ b/dap-mode.el
@@ -867,8 +867,9 @@ will be reversed."
   "Get only the buffers featuring at least one breakpoint"
   ;; extract the list of buffers featuring a breakpoint from their first breakpoint marker
   ;; (as stored in the LSP metadata)
-  (--map (marker-buffer (plist-get (car it) :marker))
-         (ht-values (dap--get-breakpoints))))
+  (delq nil (--map (when-let ((marker (plist-get (car it) :marker)))
+                     (marker-buffer marker))
+                   (ht-values (dap--get-breakpoints)))))
 
 (defun dap--refresh-breakpoints ()
   "Refresh breakpoints for DEBUG-SESSION."


### PR DESCRIPTION
# The error
The following error occurs when a debug session finishes and a buffer containing breakpoints was killed beforehand.

```
Debugger entered--Lisp error: (wrong-type-argument markerp nil)
  marker-buffer(nil)
  #f(compiled-function (it) #<bytecode -0x1fa940a0a8cd57c>)(((:point 3528)))
  mapcar(#f(compiled-function (it) #<bytecode -0x1fa940a0a8cd57c>) (((:point 3528)) ((:point 78 :marker #<marker at 78 in Main.java>))))
  dap--buffers-w-breakpoints()
  dap--refresh-breakpoints()
  dap--mark-session-as-terminated(#s(dap--debug-session :name "localhost(56283)<1>" :last-id 14 :proc #<process localhost(56283)<1>> :response-handlers #<hash-table eql 3/65 0x484ae599> :parser #s(dap--parser :waiting-for-response nil :response-result nil :headers nil :body nil :reading-body nil :body-length nil :body-received nil :leftovers "") :output-buffer #<buffer *localhost(56283)<1> out*> :thread-id nil :workspace nil :threads (#<hash-table equal 2/65 0x5012afcd> #<hash-table equal 2/65 0x5012bbbd> #<hash-table equal 2/65 0x500448bf> #<hash-table equal 2/65 0x500448df> #<hash-table equal 2/65 0x50129dad> #<hash-table equal 2/65 0x50129dcd>) :thread-states #<hash-table eql 4/65 0x484ae5cd> :active-frame-id nil :active-frame nil :cursor-marker nil :state terminated :breakpoints #<hash-table equal 0/65 0xe7681029> :thread-stack-frames #<hash-table eql 0/65 0xe7681049> :launch-args (:type "java" :request "attach" :hostName "localhost" :projectName "java-main_fe6d2076" :host "localhost" :wait-for-port t :program-to-start "java -agentlib:jdwp=transport=dt_socket,server=y,s..." :port 56283 :environment-variables (("CLASSPATH_ARGS" . "/Users/josephtesfaye/.spacemacs.d/workspace/java-m...")) :name "localhost(56283)<1>" :debugServer 56284 :__sessionId "1740794091.569148" :vmArgs nil) :local-to-remote-path-fn #f(compiled-function (&rest args2) #<bytecode -0xae28a4ee92c6a3f>) :remote-to-local-path-fn #f(compiled-function (&rest args2) #<bytecode -0xae28a4ee9272a3f>) :current-capabilities #<hash-table equal 18/65 0x49be8abd> :error-message nil :loaded-sources nil :program-proc #<process debug adapter> :metadata #<hash-table eql 0/65 0x48b31323> :output-displayed nil))
  #f(compiled-function (process exit-str) #<bytecode -0x1092c2a22582382b>)(#<process localhost(56283)<1>> "deleted\n")
  delete-process(#<process localhost(56283)<1>>)
  dap--mark-session-as-terminated(#s(dap--debug-session :name "localhost(56283)<1>" :last-id 14 :proc #<process localhost(56283)<1>> :response-handlers #<hash-table eql 3/65 0x484ae599> :parser #s(dap--parser :waiting-for-response nil :response-result nil :headers nil :body nil :reading-body nil :body-length nil :body-received nil :leftovers "") :output-buffer #<buffer *localhost(56283)<1> out*> :thread-id nil :workspace nil :threads (#<hash-table equal 2/65 0x5012afcd> #<hash-table equal 2/65 0x5012bbbd> #<hash-table equal 2/65 0x500448bf> #<hash-table equal 2/65 0x500448df> #<hash-table equal 2/65 0x50129dad> #<hash-table equal 2/65 0x50129dcd>) :thread-states #<hash-table eql 4/65 0x484ae5cd> :active-frame-id nil :active-frame nil :cursor-marker nil :state terminated :breakpoints #<hash-table equal 0/65 0xe7681029> :thread-stack-frames #<hash-table eql 0/65 0xe7681049> :launch-args (:type "java" :request "attach" :hostName "localhost" :projectName "java-main_fe6d2076" :host "localhost" :wait-for-port t :program-to-start "java -agentlib:jdwp=transport=dt_socket,server=y,s..." :port 56283 :environment-variables (("CLASSPATH_ARGS" . "/Users/josephtesfaye/.spacemacs.d/workspace/java-m...")) :name "localhost(56283)<1>" :debugServer 56284 :__sessionId "1740794091.569148" :vmArgs nil) :local-to-remote-path-fn #f(compiled-function (&rest args2) #<bytecode -0xae28a4ee92c6a3f>) :remote-to-local-path-fn #f(compiled-function (&rest args2) #<bytecode -0xae28a4ee9272a3f>) :current-capabilities #<hash-table equal 18/65 0x49be8abd> :error-message nil :loaded-sources nil :program-proc #<process debug adapter> :metadata #<hash-table eql 0/65 0x48b31323> :output-displayed nil))
  dap--on-event(#s(dap--debug-session :name "localhost(56283)<1>" :last-id 14 :proc #<process localhost(56283)<1>> :response-handlers #<hash-table eql 3/65 0x484ae599> :parser #s(dap--parser :waiting-for-response nil :response-result nil :headers nil :body nil :reading-body nil :body-length nil :body-received nil :leftovers "") :output-buffer #<buffer *localhost(56283)<1> out*> :thread-id nil :workspace nil :threads (#<hash-table equal 2/65 0x5012afcd> #<hash-table equal 2/65 0x5012bbbd> #<hash-table equal 2/65 0x500448bf> #<hash-table equal 2/65 0x500448df> #<hash-table equal 2/65 0x50129dad> #<hash-table equal 2/65 0x50129dcd>) :thread-states #<hash-table eql 4/65 0x484ae5cd> :active-frame-id nil :active-frame nil :cursor-marker nil :state terminated :breakpoints #<hash-table equal 0/65 0xe7681029> :thread-stack-frames #<hash-table eql 0/65 0xe7681049> :launch-args (:type "java" :request "attach" :hostName "localhost" :projectName "java-main_fe6d2076" :host "localhost" :wait-for-port t :program-to-start "java -agentlib:jdwp=transport=dt_socket,server=y,s..." :port 56283 :environment-variables (("CLASSPATH_ARGS" . "/Users/josephtesfaye/.spacemacs.d/workspace/java-m...")) :name "localhost(56283)<1>" :debugServer 56284 :__sessionId "1740794091.569148" :vmArgs nil) :local-to-remote-path-fn #f(compiled-function (&rest args2) #<bytecode -0xae28a4ee92c6a3f>) :remote-to-local-path-fn #f(compiled-function (&rest args2) #<bytecode -0xae28a4ee9272a3f>) :current-capabilities #<hash-table equal 18/65 0x49be8abd> :error-message nil :loaded-sources nil :program-proc #<process debug adapter> :metadata #<hash-table eql 0/65 0x48b31323> :output-displayed nil) #<hash-table equal 4/65 0xe7cac41f>)
  #f(compiled-function (m) #<bytecode 0xad9cf6823eaadc4>)("{\"event\":\"exited\",\"body\":{\"exitCode\":0,\"type\":\"exi...")
  mapc(#f(compiled-function (m) #<bytecode 0xad9cf6823eaadc4>) ("{\"success\":true,\"request_seq\":11,\"command\":\"contin..." "{\"event\":\"thread\",\"body\":{\"reason\":\"exited\",\"threa..." "{\"event\":\"thread\",\"body\":{\"reason\":\"started\",\"thre..." "{\"event\":\"thread\",\"body\":{\"reason\":\"exited\",\"threa..." "{\"event\":\"exited\",\"body\":{\"exitCode\":0,\"type\":\"exi..." "{\"event\":\"exited\",\"body\":{\"exitCode\":0,\"type\":\"exi..." "{\"event\":\"terminated\",\"body\":{\"restart\":false,\"typ..."))
  #f(compiled-function (_ msg) #<bytecode -0x1366a89f89c11565>)(#<process localhost(56283)<1>> "Content-Length: 118\15\n\15\n{\"success\":true,\"request_se...")
```
# Reproducing
**Environment**
- GNU Emacs 29.1 (build 1, aarch64-apple-darwin21.6.0, NS appkit-2113.60 Version 12.6.6 (Build 21G646)) of 2023-08-17
- Spacemacs (branch `develop`, commit `f150f1ba8c9d2cb497a790b85e46eaa1c81f7908`, with `lsp`, `java`, `dap` layers enabled)
- macOS Sequoia 15.3.1

**Steps**
1. Toggle on `debug-on-error` (Run `toggle-debug-on-error`).
2. Create two Java files containing the main method: `MainA`, `MainB`.
3. Add a breakpoint to the main method in `MainB` and then kill the buffer.
4. Run the main method in `MainA` with `dap-debug`.

**Result**
A `*Backtrace*` buffer containing the above error is shown.

# Cause & Solution
The error lies in the following function where `(plist-get (car it) :marker)` returns `nil` which is unacceptable to `marker-buffer`. This occurs when a buffer containing breakpoints was killed, which causes the absence of the `:marker` value in the result of `(dap--get-breakpoints)`. The solution here is to add a `nil`-check.

```elisp
(defun dap--buffers-w-breakpoints ()
  "Get only the buffers featuring at least one breakpoint"
  ;; extract the list of buffers featuring a breakpoint from their first breakpoint marker
  ;; (as stored in the LSP metadata)
  (--map (marker-buffer (plist-get (car it) :marker))
         (ht-values (dap--get-breakpoints))))
```
