### PR TITLE
Use pyenv to find executable only if pyenv is installed and a local shim exists for the cwd

### DIFF
--- a/dap-python.el
+++ b/dap-python.el
@@ -51,8 +51,13 @@ you are debugging."
   "Find executable COMMAND, taking pyenv shims into account.
 If the executable is a system executable and not in the same path
 as the pyenv version then also return nil. This works around
-https://github.com/pyenv/pyenv-which-ext."
-  (if (executable-find "pyenv")
+https://github.com/pyenv/pyenv-which-ext.
+
+If pyenv is not installed or if pyenv has no \"local\" version defined
+for the cwd, then fallback to `(executable-find)`, which see."
+  (if (and
+       (executable-find "pyenv")
+       (not (string-match "no local" (shell-command-to-string "pyenv local"))))
       (let ((pyenv-string (shell-command-to-string (concat "pyenv which " command)))
             (pyenv-version-names (split-string (string-trim (shell-command-to-string "pyenv version-name")) ":"))
             (executable nil)


### PR DESCRIPTION
I have a problem similar to that discussed in #126 i.e. I have `pyenv` installed, but I'm working on `pyvenv` environment with no `pyenv` "local" application-specific Python version for the current project / cwd.

Here is a "this-works-for-me" change that lets dap-mode use `pyenv` only if `pyenv local` returns something different than "pyenv: no local version configured for this directory"

Unfortunately I'm not expert enough to be sure that what I'm proposing here is always a good solution, so please feel very free to close this PR :slightly_smiling_face: 