### PR TITLE
Check supportsConfigurationDone capability before running configurationDone request

### DIFF
--- a/dap-mode.el
+++ b/dap-mode.el
@@ -1283,13 +1283,16 @@ ADAPTER-ID the id of the adapter."
 
 (defun dap--send-configuration-done (debug-session)
   "Send `configurationDone' message for DEBUG-SESSION."
-  (dap--send-message (dap--make-request "configurationDone")
-                     (dap--resp-handler
-                      (lambda (_)
-                        (when (eq 'pending (dap--debug-session-state debug-session))
-                          (setf (dap--debug-session-state debug-session) 'running)
-                          (run-hook-with-args 'dap-session-changed-hook))))
-                     debug-session))
+  (let ((callback (lambda (_)
+                    (when (eq 'pending (dap--debug-session-state debug-session))
+                      (setf (dap--debug-session-state debug-session) 'running)
+                      (run-hook-with-args 'dap-session-changed-hook)))))
+    (if (gethash "supportsConfigurationDoneRequest" (dap--debug-session-current-capabilities (dap--cur-session)))
+        (dap--send-message (dap--make-request "configurationDone")
+                           (dap--resp-handler
+                            callback)
+                           debug-session)
+      (funcall callback 'ok))))
 
 (defun dap--set-breakpoints-request (debug-session file-name file-breakpoints)
   "Make `setBreakpoints' request for FILE-NAME.

--- a/dap-mode.el
+++ b/dap-mode.el
@@ -1282,7 +1282,7 @@ ADAPTER-ID the id of the adapter."
     debug-session))
 
 (defun dap--send-configuration-done (debug-session)
-  "Send `configurationDone' message for DEBUG-SESSION."
+  "Send `configurationDone' message for DEBUG-SESSION if supported by server."
   (let ((callback (lambda (_)
                     (when (eq 'pending (dap--debug-session-state debug-session))
                       (setf (dap--debug-session-state debug-session) 'running)


### PR DESCRIPTION
Experienced a server that didn't support `configurationDone` type requests. The server was sending the correct information in the initialize response, but dap-mode still sends the request. That caused issues in the server without giving a response. dap-mode then was stuck in a non-initialized state. 


This fix simply checks if the server supports `configurationDone` by checking the capabilities. If it is supported, we just send it like normally. If not, we just run the success callback to start dap. In the cases I've tried, this resolves all issues.