### PR TITLE
Fix :args in dap-debug-edit-template (by quoting it)

### DIFF
--- a/dap-mode.el
+++ b/dap-mode.el
@@ -1939,6 +1939,7 @@ the new template can be used normally with `dap-debug'"
                do (unless (eq k :program-to-start)
                     (insert "\n")
                     (insert-char ?\s column)
+                    (when (listp v) (setq v (list 'quote v))) ; :args is often a list of strings
                     (insert (format "%s %S" k v)))))
     (insert "))"))
   (pop-to-buffer "*DAP Templates*")


### PR DESCRIPTION
This PR fixes a tiny bug with `dap-debug-edit-template` on a template with a list of `:args`.

Maintainers are encouraged to change/reject the implementation if something else is better! Thanks for great software.

Eval this snippet to demonstrate:
```
(dap-register-debug-template
   "Test template"
   (list :type "lldb-vscode"
         :cwd "/foo"
         :request "launch"
         :program "/foo/bar"
         :args '("--arg1" "v1" "--arg2" "v2" "--arg3")))
(dap-debug-edit-template (cdr (assoc "Test template" dap-debug-template-configurations)))
```

Before this PR: the template-for-editing **does not quote** the value of `:args`, and thus evaluating that is an error.
```
(dap-register-debug-template
  "Test template"
  (list :name "Test template"
        :type "lldb-vscode"
        :cwd "/foo"
        :request "launch"
        :program "/foo/bar"
        :args ("--arg1" "v1" "--arg2" "v2" "--arg3")))  ;; <-- NOTICE no quote here.
```

After this PR: the template-for-editing properly quotes it, and thus evaluating it works as expected.
```
(dap-register-debug-template
  "Test template"
  (list :name "Test template"
        :type "lldb-vscode"
        :cwd "/foo"
        :request "launch"
        :program "/foo/bar"
        :args '("--arg1" "v1" "--arg2" "v2" "--arg3")))  ;; <-- NOTICE quoted as expected.
```