### PR TITLE
feat: Drop Emacs 28.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         emacs-version:
-          - 28.2
           - 29.4
           - 30.2
         experimental: [false]

--- a/Eask
+++ b/Eask
@@ -16,7 +16,7 @@
 (source 'gnu)
 (source 'melpa)
 
-(depends-on "emacs" "28.1")
+(depends-on "emacs" "29.1")
 (depends-on "lsp-mode")
 (depends-on "lsp-treemacs")
 (depends-on "lsp-docker")

--- a/dap-mode.el
+++ b/dap-mode.el
@@ -18,7 +18,7 @@
 ;; Author: Ivan Yonchovski <yyoncho@gmail.com>
 ;; Keywords: languages, debug
 ;; URL: https://github.com/emacs-lsp/dap-mode
-;; Package-Requires: ((emacs "28.1") (dash "2.18.0") (lsp-mode "6.0") (bui "1.1.0") (f "0.20.0") (s "1.12.0") (lsp-treemacs "0.1") (posframe "0.7.0") (ht "2.3") (lsp-docker "1.0.0"))
+;; Package-Requires: ((emacs "29.1") (dash "2.18.0") (lsp-mode "6.0") (bui "1.1.0") (f "0.20.0") (s "1.12.0") (lsp-treemacs "0.1") (posframe "0.7.0") (ht "2.3") (lsp-docker "1.0.0"))
 ;; Version: 0.8
 
 ;;; Commentary:


### PR DESCRIPTION
`bui` now requires Emacs 29.1.