### PR TITLE
Drop extra progn

### DIFF
--- a/dap-python.el
+++ b/dap-python.el
@@ -53,20 +53,19 @@ If the executable is a system executable and not in the same path
 as the pyenv version then also return nil. This works around
 https://github.com/pyenv/pyenv-which-ext."
   (if (executable-find "pyenv")
-      (progn
-        (let ((pyenv-string (shell-command-to-string (concat "pyenv which " command)))
-              (pyenv-version-names (split-string (string-trim (shell-command-to-string "pyenv version-name")) ":"))
-              (executable nil)
-              (i 0))
-          (if (not (string-match "not found" pyenv-string))
-              (while (and (not executable)
-                          (< i (length pyenv-version-names)))
-                (if (string-match (elt pyenv-version-names i) (string-trim pyenv-string))
-                    (setq executable (string-trim pyenv-string)))
-                (if (string-match (elt pyenv-version-names i) "system")
-                    (setq executable (string-trim (executable-find command))))
-                (setq i (1+ i))))
-          executable))
+      (let ((pyenv-string (shell-command-to-string (concat "pyenv which " command)))
+            (pyenv-version-names (split-string (string-trim (shell-command-to-string "pyenv version-name")) ":"))
+            (executable nil)
+            (i 0))
+        (if (not (string-match "not found" pyenv-string))
+            (while (and (not executable)
+                        (< i (length pyenv-version-names)))
+              (if (string-match (elt pyenv-version-names i) (string-trim pyenv-string))
+                  (setq executable (string-trim pyenv-string)))
+              (if (string-match (elt pyenv-version-names i) "system")
+                  (setq executable (string-trim (executable-find command))))
+              (setq i (1+ i))))
+        executable)
     (executable-find command)))
 
 (cl-defstruct dap-python--point


### PR DESCRIPTION
There is a `(progn (let ...))` fragment where the `(progn)` is probably useless.

Here I propose to remove it.

The diff could show a lot of changes because of the white-space changes of re-indenting the `let` after removing the `progn`.

AFAIK, this is mostly aesthetic, feel free to disregard :slightly_smiling_face: 