### PR TITLE
Probe lldb-dap/lldb-vscode on PATH for dap-lldb-debug-program default

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -5,6 +5,7 @@
 ** Unreleased 0.9
    - Added ~dap-gdb~
    - Added ~dap-julia~
+   - ~dap-lldb-debug-program~ now defaults to ~lldb-dap~ (or the older ~lldb-vscode~) found on ~PATH~, falling back to the historical VSCode extension location.
 ** 0.8
    - [Breaking Change] Change debug provider names to match VS Code's naming: ~lldb~ to ~lldb-mi~ and ~codelldb~ to ~lldb~
    - Added ~dap-gdscript~

--- a/dap-lldb.el
+++ b/dap-lldb.el
@@ -20,14 +20,21 @@
 ;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;; Adapter for https://github.com/llvm-mirror/lldb/tree/master/tools/lldb-vscode
+;; Adapter for https://github.com/llvm/llvm-project/tree/main/lldb/tools/lldb-dap
 
 ;;; Code:
 
 (require 'dap-mode)
 
-(defcustom dap-lldb-debug-program `(,(expand-file-name "~/.vscode/extensions/llvm-org.lldb-vscode-0.1.0/bin/lldb-vscode"))
-  "The path to the LLDB debugger."
+(defcustom dap-lldb-debug-program
+  `(,(or (executable-find "lldb-dap")
+         (executable-find "lldb-vscode")
+         (expand-file-name "~/.vscode/extensions/llvm-org.lldb-vscode-0.1.0/bin/lldb-vscode")))
+  "The path to the LLDB debugger.
+
+Defaults to the first of \"lldb-dap\" (its name since LLVM 18) or
+\"lldb-vscode\" (its name before that) found via `executable-find',
+falling back to the historical VSCode extension location."
   :group 'dap-lldb
   :type '(repeat string))
 

--- a/docs/page/configuration.md
+++ b/docs/page/configuration.md
@@ -387,9 +387,9 @@ although it is not necessary to install this to use `dap-lldb` in Emacs.
     (require 'dap-lldb)
     ```
 
-    This package expects to find the `lldb-vscode` program in the extensions
-    folder used by VSCode. If you have this installed elsewhere, or are using
-    the more modern `lldb-dap` version, you will need to set or customize
+    This package looks for the `lldb-dap` (or the older `lldb-vscode`) program
+    on your `PATH`, falling back to the extensions folder used by VSCode. If
+    you have it installed somewhere else, you will need to set or customize
     `dap-lldb-debug-program` appropriately:
 
     ``` elisp


### PR DESCRIPTION
LLVM 18 renamed `lldb-vscode` to `lldb-dap`, and the `llvm-org.lldb-vscode-0.1.0` VSCode extension that the current default points at no longer exists, so out of the box `dap-lldb` fails with a missing-program error on any current system. This appears to be the root cause behind #808 and #800 (and spacemacs's syl20bnr/spacemacs#16289).

This changes the `dap-lldb-debug-program` default to probe `executable-find` for `lldb-dap`, then `lldb-vscode`, before falling back to the historical extension path, and updates the Commentary link to the adapter's current home in llvm-project (the old llvm-mirror tree is gone).

Verified end to end on macOS (Homebrew LLVM 20, Emacs 30.2): with the new default, `dap-debug` with the `lldb-vscode` provider launches `lldb-dap`, stops at a source breakpoint in a C++ program, and runs to termination with program output captured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)